### PR TITLE
Fix the TAP parser's handling of leading whitespace in comments

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@
 
     - Job listeners now receive the Test2::Harness::Job object as the first
       argument, rather than just the job id.
+    - Fixed the TAP parser to handle comments with leading
+      whitespace. Previously it would strip all the leading whitespace out,
+      causing both "# foo" and "# foo" to be output the same way.
 
 0.000011  2016-06-10 14:11:01-07:00 America/Los_Angeles
 

--- a/lib/Test2/Harness/Parser/TAP.pm
+++ b/lib/Test2/Harness/Parser/TAP.pm
@@ -292,8 +292,11 @@ sub strip_comment {
     return unless $msg || $hash || $space;
 
     $nest = length($nest) / 4;
-
-    return ($nest, $msg);
+    # We want to preserve any space in the comment _after_ the first space,
+    # since proper TAP is formatted as "# $msg". So the first space is part of
+    # the comment marker, while subsequent space is significant.
+    $space =~ s/^ //;
+    return ($nest, $space . $msg);
 }
 
 sub slurp_comments {

--- a/t/units/Harness/Parser/TAP.t
+++ b/t/units/Harness/Parser/TAP.t
@@ -580,13 +580,13 @@ subtest strip_comment => sub {
 
     is(
         [strip_comment("        #    foo\n")],
-        [2, "foo"],
+        [2, "   foo"],
         "Stripped comment, got message and nesting"
     );
 
     is(
         [strip_comment("        #    \n")],
-        [2, ""],
+        [2, "   "],
         "Stripped comment, got empty message and nesting"
     );
 
@@ -822,7 +822,9 @@ subtest parse_stdout => sub {
 
     @stdout = map { "$_\n" } split /\n/, <<'    EOT';
 ok 1 - pass
+# this note has no leading whitespace
 not ok 2 - fail
+#     this note has significant leading whitespace
 not ok 3 - todo # TODO because
 ok 4 - skip # SKIP because
     ok 1 - subtest result a
@@ -892,6 +894,19 @@ ok 10 - outer buffered subtest {
             object {
                 prop blessed          => 'Test2::Harness::Fact';
                 call event            => T();
+                call summary          => 'this note has no leading whitespace';
+                call nested           => 0;
+            }
+        ],
+        "Got a note with no leading whitespace"
+    );
+
+    like(
+        [$one->parse_stdout],
+        [
+            object {
+                prop blessed          => 'Test2::Harness::Fact';
+                call event            => T();
                 call summary          => 'fail';
                 call causes_fail      => 1;
                 call increments_count => 1;
@@ -899,6 +914,19 @@ ok 10 - outer buffered subtest {
             }
         ],
         "Fail event"
+    );
+
+    like(
+        [$one->parse_stdout],
+        [
+            object {
+                prop blessed          => 'Test2::Harness::Fact';
+                call event            => T();
+                call summary          => '    this note has significant leading whitespace';
+                call nested           => 0;
+            }
+        ],
+        "Got a note with significant leading whitespace"
     );
 
     like(


### PR DESCRIPTION
While the first space is just part of the TAP format, subsequent spaces should
be preserved. Otherwise code that does something like this:

diag('a');
diag('  b');

ends up with incorrect, confusing output.