### PR TITLE
Typo fix: DESTORY -> DESTROY

### DIFF
--- a/lib/Test2/Formatter/Test2.pm
+++ b/lib/Test2/Formatter/Test2.pm
@@ -641,7 +641,7 @@ sub render_errors {
     } @{$f->{errors}};
 }
 
-sub DESTORY {
+sub DESTROY {
     my $self = shift;
 
     my $io = $self->{+IO} or return;


### PR DESCRIPTION
I was futzing around with the output colors and happened to notice this. (If it's easier just to change it locally and ignore this PR, that's fine.)