### PR TITLE
Don't call find_yath() if we already found a yath.

### DIFF
--- a/t/failure_cases.t
+++ b/t/failure_cases.t
@@ -9,7 +9,9 @@ use File::Spec;
 
 my $dir = first { -d $_ } 't/failure_cases', 'failure_cases';
 
-my $yath = first { -f $_ } 'scripts/yath', '../scripts/yath', find_yath();
+my $yath = first { -f $_ } 'scripts/yath', '../scripts/yath';
+
+$yath ||= find_yath();
 
 my %CUSTOM = (
     "timeout.tx"           => ['--et',       2],


### PR DESCRIPTION
Otherwise, you can't install Test2::Harness without a previous
version of Test2::Harness already installed!