### PR TITLE
Mjd/help

### DIFF
--- a/lib/App/Yath/Command.pm
+++ b/lib/App/Yath/Command.pm
@@ -76,6 +76,14 @@ sub init {
 
     $self->normalize_settings();
 
+    # handle --help before the command has a chance
+    # to decide that anything might be wrong with the arguments
+    if ($settings->{help}) {
+        delete $settings->{quiet};
+        $self->paint($self->usage);
+        return;
+    }
+
     die "You cannot select both bzip2 and gzip for the log.\n"
         if $settings->{bzip2_log} && $settings->{gzip_log};
 
@@ -187,12 +195,6 @@ sub pre_run {
 
     my $settings = $self->{+SETTINGS};
 
-    if ($settings->{help}) {
-        delete $settings->{quiet};
-        $self->paint($self->usage);
-        return 0;
-    }
-
     if ($settings->{show_opts}) {
         require Test2::Harness::Util::JSON;
 
@@ -205,6 +207,10 @@ sub pre_run {
 
         return 0;
     }
+
+    # init() will already have printed the help message
+    # so there is nothing more to do
+    return 0 if $settings->{help};
 
     $self->inject_signal_handlers();
 

--- a/lib/App/Yath/Command/help.pm
+++ b/lib/App/Yath/Command/help.pm
@@ -89,7 +89,7 @@ sub command_help {
 
     require App::Yath;
     my $cmd_class = App::Yath->load_command($command);
-    print $cmd_class->new->usage;
+    print $cmd_class->usage;
 
     return 0;
 }

--- a/t/App/Yath/Command.t
+++ b/t/App/Yath/Command.t
@@ -167,6 +167,15 @@ subtest init => sub {
         },
         "Called correct plugin methods",
     );
+
+    {
+      my @painted;
+      $control->override(paint => sub { shift; push @painted => @_ });
+      my $one = $TCLASS->new();
+      $one->settings->{help} = 1;
+      $one->init;
+      is(\@painted, [$one->usage], "Painted usage info");
+    }
 };
 
 subtest normalize_settings => sub {
@@ -303,18 +312,14 @@ subtest pre_run => sub {
     my $injected = 0;
     $control->override(inject_signal_handlers => sub { $injected++ });
 
-    my @painted;
-    $control->override(paint => sub { shift; push @painted => @_ });
-
     my $one = $TCLASS->new();
 
     $one->settings->{help} = 1;
     is($one->pre_run, 0, "returned 0 for help");
-    is(\@painted, [$one->usage], "Painted usage info");
     ok(!$injected, "did not inject signal handlers");
 
-    @painted = ();
-
+    my @painted = ();
+    $control->override(paint => sub { shift; push @painted => @_ });
     delete $one->settings->{help};
     $one->settings->{show_opts} = 1;
     $one->settings->{input}     = 'foo' x 1000;

--- a/t/App/Yath/Command/help.t
+++ b/t/App/Yath/Command/help.t
@@ -14,6 +14,7 @@ sub capture(&) {
     return $stdout;
 }
 
+# MJD -- needs more tests here, some of these failed
 subtest command_help => sub {
     my $stdout = capture {
         my $one = $CLASS->new;

--- a/t/App/Yath/Command/help.t
+++ b/t/App/Yath/Command/help.t
@@ -14,13 +14,22 @@ sub capture(&) {
     return $stdout;
 }
 
-# MJD -- needs more tests here, some of these failed
 subtest command_help => sub {
-    my $stdout = capture {
+  for my $cmd (sort $CLASS->command_list) {
+    subtest "command_help_$cmd" => sub {
+      my $stdout = capture {
         my $one = $CLASS->new;
-        is($one->command_help('test'), 0, "got return of 0");
-    };
-    is($stdout, App::Yath::Command::test->usage, "printed usage of command");
+        my $res;
+        ok(lives { $res = $one->command_help($cmd) }, "ran $cmd\->command_help");
+        is($res, 0, "got return of 0");
+      };
+      if ($cmd eq "test") {
+        is($stdout, App::Yath::Command::test->usage, "printed usage of command");
+      }
+      my ($first_line) = ($stdout =~ /\A \n* (.*) \n/x);
+      like($first_line, qr#\AUsage: t/App/Yath/Command/help\.t $cmd \[options\]#, "First line of usage message");
+    }
+  }
 };
 
 subtest run => sub {

--- a/xt/author/pod-spell.t
+++ b/xt/author/pod-spell.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use Test2::Require::AuthorTesting;
-use Test::Spelling;
+use Test2::Require::Module 'Test::Spelling';
 
 my @stopwords;
 for (<DATA>) {


### PR DESCRIPTION
The first commit, 8fe5d3f, is not related to the others, and can be discarded without affecting the others.

The other three make `yath subcommand --help` and  `yath help subcommand` work for all subcommands, and add regression tests to check that these continue to work for all subcommands that are distributed with Yath.

