### PR TITLE
fix for issue #73.

### DIFF
--- a/lib/Test2/Harness/Util/TestFile.pm
+++ b/lib/Test2/Harness/Util/TestFile.pm
@@ -159,7 +159,16 @@ sub _scan {
         next if $line =~ m/^\s*(use|require|BEGIN|package)\b/;          # Only supports single line BEGINs
         last unless $line =~ m/^\s*#\s*HARNESS-(.+)$/;
 
-        my ($dir, @args) = split /[-\s]+/, lc($1);
+        my ($dir, $rest) = split /[-\s]+/, lc($1), 2;
+        $rest =~ s/\s*(?:#.*)?$//;                                      # Strip trailing white space and comment if present
+        my @args;
+        if ($dir eq 'meta') {
+            @args = split /\s+/, $rest, 2;                              # Check for white space delimited
+            @args = split(/[-]+/, $rest, 2) if scalar @args == 1;       # Check for dash delimited
+        }
+        else {
+            @args = split /[-\s]+/, $rest;
+        }
 
         if ($dir eq 'no') {
             my ($feature) = @args;
@@ -185,7 +194,6 @@ sub _scan {
             my @conflicts_array;
 
             foreach my $arg (@args) {
-                last if $arg =~ m/^#/;    # Stop accepting conflict categories after a comment sign.
                 push @conflicts_array, $arg;
             }
 

--- a/t/Test2/Harness/Util/TestFile.t
+++ b/t/Test2/Harness/Util/TestFile.t
@@ -13,7 +13,7 @@ my $tmp = gen_temp(
     warn   => "#!/usr/bin/perl -w\n",
     taint  => "#!/usr/bin/env perl -t -w\n",
     foo    => "#HARNESS-CATEGORY-FOO\n#HARNESS-STAGE-FOO",
-    meta   => "#HARNESS-META-mykey-myval\n# HARNESS-META-otherkey-otherval\n# HARNESS-META mykey myval2\n",
+    meta   => "#HARNESS-META-mykey-myval\n# HARNESS-META-otherkey-otherval\n# HARNESS-META mykey my-val2\n# HARNESS-META my-key my-val # comment after harness statement\n",
 
     package => "package Foo::Bar::Baz;\n# HARNESS-NO-PRELOAD\n",
 
@@ -60,10 +60,11 @@ subtest invalid => sub {
 subtest meta => sub {
     my $foo = $CLASS->new(file => File::Spec->catfile($tmp, 'meta'));
 
-    is([$foo->meta],             [],                 "No key returns empty list");
-    is([$foo->meta('foo')],      [],                 "Empty key returns empty list");
-    is([$foo->meta('mykey')],    [qw/myval myval2/], "Got both values for the 'mykey' key");
-    is([$foo->meta('otherkey')], ['otherval'],       "Got other key");
+    is([$foo->meta],             [],                  "No key returns empty list");
+    is([$foo->meta('foo')],      [],                  "Empty key returns empty list");
+    is([$foo->meta('mykey')],    [qw/myval my-val2/], "Got both values for the 'mykey' key");
+    is([$foo->meta('otherkey')], ['otherval'],        "Got other key");
+    is([$foo->meta('my-key')],   ['my-val'],          "Got hyphenated key");
 };
 
 subtest foo => sub {


### PR DESCRIPTION
all of the harness directives expect a single word followed by
other stuff so do that first so we can treat 'meta' special.

meta expects 2 items, a key and a value.  they can be either white
space delimited, or dash delimited.

also, allow all directives to end with optional white space and a
comment.

add test to validate trailing comment, hyphenated keys and hyphenated
values for the meta harness directive.