### PR TITLE
Fix for Issue #73

### DIFF
--- a/lib/Test2/Harness/Util/TestFile.pm
+++ b/lib/Test2/Harness/Util/TestFile.pm
@@ -159,7 +159,16 @@ sub _scan {
         next if $line =~ m/^\s*(use|require|BEGIN|package)\b/;          # Only supports single line BEGINs
         last unless $line =~ m/^\s*#\s*HARNESS-(.+)$/;
 
-        my ($dir, @args) = split /[-\s]+/, lc($1);
+        my ($dir, $rest) = split /[-\s]+/, lc($1), 2;
+        $rest =~ s/\s*(?:#.*)?$//;                                      # Strip trailing white space and comment if present
+        my @args;
+        if ($dir eq 'meta') {
+            @args = split /\s+/, $rest, 2;                              # Check for white space delimited
+            @args = split(/[-]+/, $rest, 2) if scalar @args == 1;       # Check for dash delimited
+        }
+        else {
+            @args = split /[-\s]+/, $rest;
+        }
 
         if ($dir eq 'no') {
             my ($feature) = @args;
@@ -185,7 +194,6 @@ sub _scan {
             my @conflicts_array;
 
             foreach my $arg (@args) {
-                last if $arg =~ m/^#/;    # Stop accepting conflict categories after a comment sign.
                 push @conflicts_array, $arg;
             }
 

--- a/lib/Test2/Harness/Util/TestFile.pm
+++ b/lib/Test2/Harness/Util/TestFile.pm
@@ -160,13 +160,14 @@ sub _scan {
         last unless $line =~ m/^\s*#\s*HARNESS-(.+)$/;
 
         my ($dir, $rest) = split /[-\s]+/, lc($1), 2;
-        $rest =~ s/\s*(?:#.*)?$//;                                      # Strip trailing white space and comment if present
         my @args;
         if ($dir eq 'meta') {
             @args = split /\s+/, $rest, 2;                              # Check for white space delimited
             @args = split(/[-]+/, $rest, 2) if scalar @args == 1;       # Check for dash delimited
+            $args[1] =~ s/\s+(?:#.*)?$//;                               # Strip trailing white space and comment if present
         }
         else {
+            $rest =~ s/\s+(?:#.*)?$//;                                  # Strip trailing white space and comment if present
             @args = split /[-\s]+/, $rest;
         }
 

--- a/t/Test2/Harness/Util/TestFile.t
+++ b/t/Test2/Harness/Util/TestFile.t
@@ -13,7 +13,7 @@ my $tmp = gen_temp(
     warn   => "#!/usr/bin/perl -w\n",
     taint  => "#!/usr/bin/env perl -t -w\n",
     foo    => "#HARNESS-CATEGORY-FOO\n#HARNESS-STAGE-FOO",
-    meta   => "#HARNESS-META-mykey-myval\n# HARNESS-META-otherkey-otherval\n# HARNESS-META mykey my-val2\n# HARNESS-META my-key my-val # comment after harness statement\n",
+    meta   => "#HARNESS-META-mykey-myval\n# HARNESS-META-otherkey-otherval\n# HARNESS-META mykey my-val2\n# HARNESS-META slack #my-val # comment after harness statement\n",
 
     package => "package Foo::Bar::Baz;\n# HARNESS-NO-PRELOAD\n",
 
@@ -64,7 +64,7 @@ subtest meta => sub {
     is([$foo->meta('foo')],      [],                  "Empty key returns empty list");
     is([$foo->meta('mykey')],    [qw/myval my-val2/], "Got both values for the 'mykey' key");
     is([$foo->meta('otherkey')], ['otherval'],        "Got other key");
-    is([$foo->meta('my-key')],   ['my-val'],          "Got hyphenated key");
+    is([$foo->meta('slack')],    ['#my-val'],         "Got hyphenated key");
 };
 
 subtest foo => sub {

--- a/t/Test2/Harness/Util/TestFile.t
+++ b/t/Test2/Harness/Util/TestFile.t
@@ -13,7 +13,7 @@ my $tmp = gen_temp(
     warn   => "#!/usr/bin/perl -w\n",
     taint  => "#!/usr/bin/env perl -t -w\n",
     foo    => "#HARNESS-CATEGORY-FOO\n#HARNESS-STAGE-FOO",
-    meta   => "#HARNESS-META-mykey-myval\n# HARNESS-META-otherkey-otherval\n# HARNESS-META mykey myval2\n",
+    meta   => "#HARNESS-META-mykey-myval\n# HARNESS-META-otherkey-otherval\n# HARNESS-META mykey my-val2\n# HARNESS-META my-key my-val # comment after harness statement\n",
 
     package => "package Foo::Bar::Baz;\n# HARNESS-NO-PRELOAD\n",
 
@@ -60,10 +60,11 @@ subtest invalid => sub {
 subtest meta => sub {
     my $foo = $CLASS->new(file => File::Spec->catfile($tmp, 'meta'));
 
-    is([$foo->meta],             [],                 "No key returns empty list");
-    is([$foo->meta('foo')],      [],                 "Empty key returns empty list");
-    is([$foo->meta('mykey')],    [qw/myval myval2/], "Got both values for the 'mykey' key");
-    is([$foo->meta('otherkey')], ['otherval'],       "Got other key");
+    is([$foo->meta],             [],                  "No key returns empty list");
+    is([$foo->meta('foo')],      [],                  "Empty key returns empty list");
+    is([$foo->meta('mykey')],    [qw/myval my-val2/], "Got both values for the 'mykey' key");
+    is([$foo->meta('otherkey')], ['otherval'],        "Got other key");
+    is([$foo->meta('my-key')],   ['my-val'],          "Got hyphenated key");
 };
 
 subtest foo => sub {


### PR DESCRIPTION
correctly handles slack channel names and comments on the same line as the directive as long as the directive is first.