### PR TITLE
Allow --no-fork and --no-preload simultaneously

### DIFF
--- a/lib/App/Yath/Command.pm
+++ b/lib/App/Yath/Command.pm
@@ -640,6 +640,11 @@ sub options {
             section => 'Harness Options',
             usage   => ['-P Module', '--preload Module'],
             summary => ['Preload a module before running tests', 'this option may be given multiple times'],
+            action => sub {
+                my $self = shift;
+                my ($settings, $field, $arg, $opt) = @_;
+                push @{$settings->{preload}}, $arg;
+            },
         },
 
         {
@@ -653,8 +658,7 @@ sub options {
             action => sub {
                 my $self = shift;
                 my ($settings, $field, $arg, $opt) = @_;
-                return unless $settings->{preload};
-                @{$settings->{preload}} = ();
+                delete $settings->{preload};
             },
         },
 

--- a/t/App/Yath/Command.t
+++ b/t/App/Yath/Command.t
@@ -803,6 +803,9 @@ subtest options => sub {
 
         my $three = $TCLASS->new(args => {opts => ['-PScalar::Util', '--preload', 'List::Util', '--no-preload', '-PData::Dumper']});
         is($three->settings->{preload}, ['Data::Dumper'], "Added preload after canceling previous ones");
+
+        my $four = $TCLASS->new(args => {opts => ['-PScalar::Util', '--preload', 'List::Util', '--no-preload']});
+        is($four->settings->{preload}, undef, "Clearing preloads puts setting back at undef");
     };
 
     subtest plugin => sub {


### PR DESCRIPTION
Rather than setting $settings->{preload} to an empty arrayref, set it
to undef.  Otherwise we trigger the later warning in
Test2::Harness::Run: "Preload requires forking".

Note: it would be nice to have just left the --preload using the
default action, but as far as I know there's no way to unvivify a
undef reference without destroying the reference.  i.e. --preload
would keep putting it into the original arrayref after a --no-preload.