### PR TITLE
Miscellaneous fixes around Formatter::Stream and the IPC runner

### DIFF
--- a/lib/Test2/Formatter/Stream.pm
+++ b/lib/Test2/Formatter/Stream.pm
@@ -85,6 +85,7 @@ sub new_root {
     my $class = shift;
     my %params = @_;
 
+    $ROOT_PID //= $$;
     confess "new_root called from child process!"
         if $ROOT_PID != $$;
 

--- a/lib/Test2/Harness/Job/Dir.pm
+++ b/lib/Test2/Harness/Job/Dir.pm
@@ -266,7 +266,9 @@ sub _poll_event {
     my $buffer = $self->{+_EVENTS_BUFFER};
     return unless @$buffer;
 
-    my $event_data = decode_json($buffer->[0]);
+    my $event_data = ref($buffer->[0]) eq "HASH"
+        ? $buffer->[0]
+        : decode_json($buffer->[0]);
     my $id = $event_data->{stream_id};
 
     # We need to wait for these to catch up.

--- a/lib/Test2/Harness/Job/Dir.pm
+++ b/lib/Test2/Harness/Job/Dir.pm
@@ -435,6 +435,7 @@ sub _process_stdout_line {
         $event_data->{stream_id} = $sid;
         $event_data->{event_id} ||= $event_data->{facet_data}->{about}->{uuid} ||= gen_uuid();
         push @event_datas => $event_data;
+        $line = undef if $line eq "";
     }
 
     if (defined $line) {

--- a/lib/Test2/Harness/Job/Runner/IPC.pm
+++ b/lib/Test2/Harness/Job/Runner/IPC.pm
@@ -65,7 +65,10 @@ sub run {
 
     my $env = {
         %{$job->env_vars},
-        $job->use_stream ? (T2_FORMATTER => 'Stream') : (),
+        $job->use_stream
+            ? ( T2_FORMATTER => 'Stream',
+                T2_STREAM_FILE => $event_file )
+            : (),
     };
 
     my %seen;

--- a/t2/ipc_reexec.t
+++ b/t2/ipc_reexec.t
@@ -1,0 +1,10 @@
+# HARNESS-NO-FORK
+BEGIN { $INC{'Test2/Formatter/Stream.pm'} && exec($^X, $0); };
+# Force into stdout
+BEGIN { delete $ENV{T2_STREAM_FILE} };
+
+use Test::Builder;
+use Test2::V0;
+
+ok 1, "test runs correctly in IPC mode";
+done_testing;


### PR DESCRIPTION
Several bugs around using the Stream formatter, specifically when the subprocess re-exec's itself.