### PR TITLE
Allow `yath projects` to run `--author-testing` tests.

### DIFF
--- a/lib/App/Yath/Command/projects.pm
+++ b/lib/App/Yath/Command/projects.pm
@@ -27,8 +27,17 @@ This command will run all the tests for each project within a parent directory.
 sub make_run_from_settings {
     my $self = shift;
 
+    # Add the Author Testing search paths if enabled
+    my $settings       = $self->{+SETTINGS} ||= {};
+    my @default_search = @{$settings->{default_search}};
+    if ($ENV{AUTHOR_TESTING} || $settings->{env_vars}{AUTHOR_TESTING}) {
+        push @default_search, @{$settings->{default_at_search}};
+    }
+
+    # Go set up our test runner.
     return $self->SUPER::make_run_from_settings(
-        projects => 1,
+        projects       => 1,
+        default_search => \@default_search,
     );
 }
 


### PR DESCRIPTION
When building our test runner we need to add in our "author tests" to
the search path or they won't get run.

Uses the same logic to add them here as is found in
`App::Yath::Command::test::handle_list_args()`.