### PR TITLE
Allow plugins to specify custom job runners on self-added files

### DIFF
--- a/lib/Test2/Harness/Util/TestFile.pm
+++ b/lib/Test2/Harness/Util/TestFile.pm
@@ -19,6 +19,7 @@ use Test2::Harness::Util::UUID qw/gen_uuid/;
 use Test2::Harness::Util::HashBase qw{
     -file -_scanned -_headers -_shbang -queue_args
     _category _stage
+    -via
 };
 
 *set_category = \&set__category;
@@ -274,6 +275,7 @@ sub queue_item {
         use_stream  => $stream,
         use_timeout => $timeout,
         conflicts   => $self->conflicts_list,
+        via         => $self->via,
 
         event_timeout    => $self->event_timeout,
         postexit_timeout => $self->postexit_timeout,


### PR DESCRIPTION
By specifying the 'via' attribute on instances of
Test2::Harness::Util::TestFile returned from $plugin->find_files(),
this change allows plugins to override the value selected by
default in Test2::Harness::Run::Runner.
I.e. this change allows specification of a value for '$task->{via}'
in Test2::Harness::Run::Runner::run_job.