### PR TITLE
[major_refactor] Consistent signal setup

### DIFF
--- a/lib/App/Yath/Command/runner.pm
+++ b/lib/App/Yath/Command/runner.pm
@@ -9,6 +9,7 @@ use goto::file();
 use Test2::Harness::IPC();
 
 use Carp qw/confess/;
+use Config qw/%Config/;
 use Scalar::Util qw/openhandle/;
 use List::Util qw/first/;
 use File::Path qw/remove_tree/;
@@ -56,7 +57,9 @@ sub generate_run_sub {
     my $runner_pid = $$;
     my $jump = setjump "Test-Runner" => sub {
         local $.;
-        local %SIG = %SIG;
+        my @SIGNAMES = grep { $_ ne 'ZERO' } split /\s+/, $Config{sig_name};
+        local @SIG{ @SIGNAMES } = @SIG{ @SIGNAMES };
+
         my $runner = $settings->build(
             runner => 'Test2::Harness::Runner',
 

--- a/t/integration/signals.t
+++ b/t/integration/signals.t
@@ -1,0 +1,24 @@
+use Test2::V0;
+
+use File::Temp qw/tempdir/;
+use File::Spec;
+
+use Test2::Harness::Util::File::JSONL;
+use App::Yath::Tester qw/yath/;
+
+my $dir = __FILE__;
+$dir =~ s{\.t$}{}g;
+
+for ( 1..10 ) {
+    # the tests are flapping when using something like '%INC = %INC'....
+    #   make sure the issue is fixed by running them a few times
+    my $out = yath(
+        command => 'test',
+        args    => [$dir],
+        log     => 1,
+        exit    => 0,
+    );
+
+}
+
+done_testing;

--- a/t/integration/signals/abrt_or_iot.t
+++ b/t/integration/signals/abrt_or_iot.t
@@ -1,0 +1,17 @@
+#!perl
+
+use strict;
+use warnings;
+use Test::More;
+
+# note: this is going to fail if IOT is defined before...
+# %SIG = %SIG; will introduce a flapping behavior
+
+$SIG{'ABRT'} = sub {
+  my ($sig) = @_;
+  is $sig, 'ABRT';
+};
+
+kill 'ABRT', $$;
+
+done_testing;


### PR DESCRIPTION
This is a regression noticed with the 'major_refactor'
and signal improvements.

As shown by the provided test 'signals/abrt_or_iot.t',
this is flapping when using yath, whereas it's consistent
when using prove.

The root of the issue is the 'local %SIG = %SIG' which
has multiple issues.

1/ 'local %SIG' does not work, signals are not restored
when exiting the scope.

2/ '%SIG = %SIG' is also bad as it forces a hash setup
in a random order due to hash keys ordering...

Several signals are using multiple names for the same id:
- ABRT and IOT
- CHLD and CLD
- IO and POLL
- SYS and UNUSED

When relying on the signal name has shown by 'abrt_or_iot.t'
the first signal set is the one giving its name to the signal,
even if the signal is undefined...

By forcing the signal names to be ordered in the same way they
are listed in Config, we provide a consistent behavior and will
always use the same signal name.