### PR TITLE
[major_refactor] Make sure excluded files are excluded

### DIFF
--- a/lib/Test2/Harness/Finder.pm
+++ b/lib/Test2/Harness/Finder.pm
@@ -164,7 +164,7 @@ sub find_project_files {
         my $test;
         unless (first { $test = $_->claim_file($path, $settings) } @$plugins) {
             $test = Test2::Harness::TestFile->new(file => $path);
-            next unless @$input || $self->include_file($test);
+            next unless @$input && $self->include_file($test);
         }
 
         push @tests => $test;

--- a/t/integration/test.t
+++ b/t/integration/test.t
@@ -57,6 +57,18 @@ yath(
     },
 );
 
+yath(
+    command => 'test',
+    args    => [ "--exclude-file=$dir/fail.txx", "$dir/pass.tx", "$dir/fail.txx" ],
+    exit    => 0,
+    test    => sub {
+        my $out = shift;
+
+        unlike($out->{output}, qr{FAILED.*fail\.tx}, "'fail.tx' was excluded using '--exclude-file' option");
+        like($out->{output}, qr{PASSED.*pass\.tx}, "'pass.tx' was not seen as a failure when reading the output");
+    },
+);
+
 {
     my $sdir = $dir . '-symlinks';
     my $base    = "$sdir/_base.xt";


### PR DESCRIPTION
Also add one integration test to confirm excluded files
are excluded as expected.

It's common to do something like this
    yath test --exclude-file t/boom.t t/*.t