### PR TITLE
[major_refactor] Do not add '.' to @INC by default.

### DIFF
--- a/lib/App/Yath/Options/Runner.pm
+++ b/lib/App/Yath/Options/Runner.pm
@@ -62,7 +62,7 @@ option_group {prefix => 'runner', category => "Runner Options"} => sub {
     option unsafe_inc => (
         description => "perl is removing '.' from \@INC as a security concern. This option keeps things from breaking for now.",
         env_vars    => [qw/PERL_USE_UNSAFE_INC/],
-        default     => 1,
+        default     => 0,
     );
 
     option preloads => (


### PR DESCRIPTION
Use sane default values for @INC.

The default behavior should be the sane and recommended
one, all the most it matches Perl default values.

This is great that we have an option to add '.' in @INC
when needed but this should not be the default.