### PR TITLE
[major_refactor] Do not use relative path in @INC

### DIFF
--- a/lib/App/Yath/Command/runner.pm
+++ b/lib/App/Yath/Command/runner.pm
@@ -20,7 +20,7 @@ use Test2::Util qw/clone_io/;
 
 use Long::Jump qw/setjump longjump/;
 
-use Test2::Harness::Util qw/mod2file write_file_atomic open_file/;
+use Test2::Harness::Util qw/mod2file write_file_atomic open_file clean_path/;
 
 use Test2::Harness::Util::IPC qw/swap_io/;
 
@@ -277,7 +277,7 @@ sub build_init_state {
 
     # Make sure our specified includes are at the front of the list.
     my %seen;
-    @INC = grep { !$seen{$_}++ } $job->unsafe_inc ? ('.') : (), $job->includes, @INC;
+    @INC = grep { !$seen{$_}++ } $job->unsafe_inc ? ('.') : (), map { clean_path( $_ ) } $job->includes, @INC;
 
     # if FindBin is preloaded, reset it with the new $0
     FindBin::init() if defined &FindBin::init;

--- a/lib/App/Yath/Tester.pm
+++ b/lib/App/Yath/Tester.pm
@@ -90,6 +90,7 @@ sub yath {
 
     local %ENV = %ENV;
     $ENV{YATH_PERSISTENCE_DIR} = $pdir;
+    $ENV{YATH_CMD} = $cmd;
     $ENV{NESTED_YATH} = 1;
     $ENV{$_} = $env->{$_} for keys %$env;
     my $pid = run_cmd(

--- a/t/integration/test-inc/check-INC.tx
+++ b/t/integration/test-inc/check-INC.tx
@@ -1,0 +1,18 @@
+package My::Simple::Test;
+
+use Test2::V0;
+
+my $has_dot_in_inc = grep { $_ eq '.' } @INC;
+ok !$has_dot_in_inc, q['.' is not in @INC run with --no-unsafe-inc];
+
+{	# relative path in @INC
+	my @relative_path = grep { index( $_, '/', 0 ) != 0 } @INC;
+	is \@relative_path, [], q[@INC does not contain relative path];
+}
+
+{  # check elative path in %INC
+	my @relative_path = grep { index( $_, '/', 0 ) != 0 } sort values %INC;
+	is \@relative_path, [], q[%INC does not contain relative path values];
+}
+
+done_testing;

--- a/t/integration/test.t
+++ b/t/integration/test.t
@@ -6,6 +6,7 @@ use File::Spec;
 use App::Yath::Tester qw/yath/;
 use Test2::Harness::Util::File::JSONL;
 
+use Test2::Harness::Util       qw/clean_path/;
 use Test2::Harness::Util::JSON qw/decode_json/;
 
 my $dir = __FILE__;
@@ -168,6 +169,26 @@ yath(
 
                 end;
             }, "tests are run in order from slow to fast - using a list of files";
+        },
+    );
+}
+
+{
+    note q[Checking %INC and @INC setup];
+
+    local @INC =  map { clean_path( $_ ) } grep { $_ ne '.' } @INC;
+    local $ENV{PERL5LIB} = join ':', map { clean_path( $_ ) } grep { $_ ne '.' } split( ':', $ENV{PERL5LIB} );
+
+    my $sdir = $dir . '-inc';
+
+    yath(
+        command => 'test',
+        args => [ '-v', '--ext=tx', '--no-unsafe-inc', $sdir ],
+        exit => 0,
+        test => sub {
+            my $out = shift;
+
+            unlike($out->{output}, qr{FAILED}, q[no failures]);
         },
     );
 }


### PR DESCRIPTION
Using relative path in @INC could lead to unexpected behavior.
Code can be loaded from uncontrolled locations.

When setting @INC with devlib: 'lib', 'blib', 'blib/arch'
we should not use the relative PATH but prefer the absolute one.

Note that the workardound for 'projects' command need some extra love,
as this seems to be the expected behavior for projects, we should avoid
using an environment variable.

note: built on top of #136 