### PR TITLE
[major_refactor] Preserve test --retry meaning

### DIFF
--- a/lib/Test2/Harness/Runner.pm
+++ b/lib/Test2/Harness/Runner.pm
@@ -412,7 +412,7 @@ sub set_proc_exit {
     if ($proc->isa('Test2::Harness::Runner::Job')) {
         my $task = $proc->task;
 
-        if ($exit && $proc->is_try < ($proc->retry - 1)) {
+        if ($exit && $proc->is_try < $proc->retry ) {
             $self->state->retry_task($task->{job_id});
             push @args => 'will-retry';
         }

--- a/lib/Test2/Harness/TestFile.pm
+++ b/lib/Test2/Harness/TestFile.pm
@@ -245,13 +245,13 @@ sub _scan {
             $headers{features}->{smoke} = 1;
         }
         elsif ($dir eq 'retry') {
-            $headers{retry} = 2 unless @args;
+            $headers{retry} = 1 unless @args;
             for my $arg (@args) {
-                if ($arg =~ m/^\d+$/) {
-                    $headers{retry} = $arg + 1;
+                if ($arg =~ m/^\d+$/a) {
+                    $headers{retry} = int $arg;
                 }
                 elsif ($arg =~ m/^iso/i) {
-                    $headers{retry} //= 2;
+                    $headers{retry} //= 1;
                     $headers{retry_isolated} = 1;
                 }
                 else {

--- a/t/integration/retry.t
+++ b/t/integration/retry.t
@@ -63,7 +63,7 @@ sub run_tests {
             my $retry_data = $final->{facet_data}->{harness_final}->{retried}->[0];
             my ($uuid, $tries, $file, $status) = @$retry_data;
 
-            is($tries, 3, "Tried 3 times");
+            is($tries, 4, "Tried 4 times: 1 run + 3 retries");
             like($file, qr{retry\.tx}, "Retried the right file");
             is($status, 'NO', "Never passed");
         },

--- a/t/unit/Test2/Harness/TestFile.t
+++ b/t/unit/Test2/Harness/TestFile.t
@@ -31,7 +31,8 @@ my $tmp = gen_temp(
 
     smoke1     => "#HARNESS-SMOKE\n",
     smoke2     => "#HARNESS-YES-SMOKE\n",
-    retry      => "#HARNESS-RETRY\n",
+
+    retry      => "#HARNESS-RETRY\n",     # mean retry once => --retry similar to --retry=1
     retry5     => "#HARNESS-RETRY 5\n",
     retry_iso  => "#HARNESS-RETRY-ISO\n",
     retry_iso3 => "#HARNESS-RETRY-ISO 3\n",
@@ -638,22 +639,22 @@ subtest smoke => sub {
 subtest smoke => sub {
     my $retry = $CLASS->new(file => File::Spec->catfile($tmp, 'retry'));
     my $task = $retry->queue_item(42);
-    is($task->{retry}, 2, "Enabled retry");
+    is($task->{retry}, 1, "Enabled retry");
     ok(!exists($task->{retry_isolated}), "not isolated");
 
     $retry = $CLASS->new(file => File::Spec->catfile($tmp, 'retry5'));
     $task = $retry->queue_item(42);
-    is($task->{retry}, 6, "Enabled retry, value of 5 results in '6' because of initial try");
+    is($task->{retry}, 5, "Enabled retry, value of 5 results in '6' because of initial try");
     ok(!exists($task->{retry_isolated}), "not isolated");
 
     $retry = $CLASS->new(file => File::Spec->catfile($tmp, 'retry_iso'));
     $task = $retry->queue_item(42);
-    is($task->{retry}, 2, "Enabled retry");
+    is($task->{retry}, 1, "Enabled retry");
     is($task->{retry_isolated}, T(), "isolated retry");
 
     $retry = $CLASS->new(file => File::Spec->catfile($tmp, 'retry_iso3'));
     $task = $retry->queue_item(42);
-    is($task->{retry}, 4, "Enabled retry, 1 initital + 3 retries");
+    is($task->{retry}, 3, "Enabled retry, 1 initital + 3 retries");
     is($task->{retry_isolated}, T(), "isolated retry");
 };
 


### PR DESCRIPTION
We should not need to set '--retry=2' to retry a test.
The previous implementation would be more accurate if we
rename '--retry' '--run-up-to-x-times'.

As documented:
"retry=1 means failing tests will be attempted twice"

--retry and --retry=1 should be similar and should request for
a job to be run one more time on failure.

--retry=0 is similar to --no-retry
--retry=1 try an extra time if it fails, which can run the test
up to two times
--retry=2 try to rerun a failing test up to twice, so up to three runss
...