### PR TITLE
fixed issue with confused @INC in generate_options_pod

### DIFF
--- a/release-scripts/generate_options_pod.pl
+++ b/release-scripts/generate_options_pod.pl
@@ -2,12 +2,13 @@
 use strict;
 use warnings;
 
-require App::Yath::Command;
 
 die "No directory specified" unless @ARGV;
 chdir($ARGV[0]) or die "Could not chdir to $ARGV[0]";
 
 unshift @INC => './lib';
+
+require App::Yath::Command;
 
 for my $base ('./lib/App/Yath/Options', './lib/App/Yath/Plugin') {
     opendir(my $dh, $base) or die "Could not open dir '$base': $!";


### PR DESCRIPTION
The change to @INC was running too late, so I couldn't build the dist with an old yath installed. This change moves the edit to @INC early enough that it only loads the correct modules.