### PR TITLE
[major_refactor] Move Devel::AssertOS outside of Dist::Zilla vision

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -43,8 +43,10 @@ jobs:
       - uses: actions/checkout@v1
       - name: perl -V
         run: perl -V
+      - name: Install Dependencies CI
+        run: cpm install -g --show-build-log-on-failure --cpanfile cpanfile.ci
       - name: Install Dependencies
-        run: curl -sL https://git.io/cpm | perl - install -g --show-build-log-on-failure
+        run: cpm install -g --show-build-log-on-failure --cpanfile cpanfile
       - name: perl Makefile.PL
         run: perl Makefile.PL
       # test are looping on linux containers # need investigation

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,6 +26,8 @@ jobs:
         run: brew install perl
       - name: perl -V
         run: perl -V
+      - name: Install Dependencies CI
+        run: curl -sL https://git.io/cpm | perl - install -g --show-build-log-on-failure --cpanfile cpanfile.ci
       - name: Install Dependencies
         run: curl -sL https://git.io/cpm | perl - install -g --show-build-log-on-failure
       - name: perl Makefile.PL

--- a/cpanfile
+++ b/cpanfile
@@ -3,7 +3,6 @@ requires "Config" => "0";
 requires "Cwd" => "0";
 requires "Data::Dumper" => "0";
 requires "Data::UUID" => "1.148";
-requires "Devel::AssertOS" => "0";
 requires "Exporter" => "0";
 requires "Fcntl" => "0";
 requires "File::Find" => "0";

--- a/cpanfile.ci
+++ b/cpanfile.ci
@@ -1,0 +1,5 @@
+# modules required for Continuous Integrations
+#   outside of Dist::Zilla vision
+
+requires "Devel::AssertOS" => "0";
+

--- a/dist.ini
+++ b/dist.ini
@@ -24,6 +24,7 @@ exclude_match = ^t2/
 exclude_filename = LICENSE
 exclude_filename = Makefile.PL
 exclude_filename = cpanfile
+exclude_filename = cpanfile.ci
 exclude_filename = README
 exclude_filename = README.md
 exclude_filename = .yath-persist.json


### PR DESCRIPTION
This is fixing Continuous Integration smokers