### PR TITLE
Skip symlink tests when failing to create link

### DIFF
--- a/t/integration/retry.t
+++ b/t/integration/retry.t
@@ -84,7 +84,7 @@ sub run_tests {
         my $symlink = "$sdir/symlink.tl";
 
         unlink $symlink if -e $symlink;
-        if ( eval{ symlink('retry.tx', $symlink); 1 } ) {
+        if ( eval{ symlink('retry.tx', $symlink) } ) {
             yath(
                 command => 'test',
                 args => [$sdir, '--ext=tl', '--retry' => 1, '--env-var' => "FAIL_ONCE=1", '-v' ],

--- a/t/integration/test.t
+++ b/t/integration/test.t
@@ -82,7 +82,7 @@ yath(
     my $symlink = "$sdir/symlink_to_base.xt";
 
     unlink $symlink if -e $symlink;
-    if ( eval{ symlink('_base.xt', $symlink); 1 } ) {
+    if ( eval{ symlink('_base.xt', $symlink) } ) {
 
         yath(
             command => 'test',
@@ -120,7 +120,7 @@ yath(
     my $symlink = "$sdir/broken-symlink.tx";
 
     unlink $symlink if -e $symlink;
-    if ( eval{ symlink('nothing-there', $symlink); 1 } ) {
+    if ( eval{ symlink('nothing-there', $symlink) } ) {
 
         yath(
             command => 'test',


### PR DESCRIPTION
Attempt to fix http://www.cpantesters.org/cpan/report/22fb7c62-5a71-11ea-b256-e4621f24ea8f
This should be enough, need to confirm it's fine otherwise I got some additional ideas.. for example adding a `-l _` checks