### PR TITLE
--exclude-list option

### DIFF
--- a/lib/App/Yath/Command/speedtag.pm
+++ b/lib/App/Yath/Command/speedtag.pm
@@ -22,7 +22,7 @@ option_group {prefix => 'speedtag', category => 'speedtag options'} => sub {
     option generate_durations_file => (
         type => 'd',
         alt         => ['durations', 'duration'],
-        description => "Write out a duration json file, if no path is provided 'duration.json' will be used. The .json extention is added automatically if omitted.",
+        description => "Write out a duration json file, if no path is provided 'duration.json' will be used. The .json extension is added automatically if omitted.",
 
         long_examples  => ['', '=/path/to/durations.json'],
 

--- a/lib/App/Yath/Command/test.pm
+++ b/lib/App/Yath/Command/test.pm
@@ -72,7 +72,7 @@ sub description {
     return <<"    EOT";
 This yath command (which is also the default command) will run all the test
 files for the current project. If no test files are specified this command will
-look for the 't', and 't2' dirctories, as well as the 'test.pl' file.
+look for the 't', and 't2' directories, as well as the 'test.pl' file.
 
 This command is always recursive when given directories.
 

--- a/lib/App/Yath/Option.pm
+++ b/lib/App/Yath/Option.pm
@@ -500,7 +500,7 @@ Real world example from the debug options (simplified for doc purposes):
 
     option summary => (
         type        => 'd',
-        description => "Write out a summary json file, if no path is provided 'summary.json' will be used. The .json extention is added automatically if omitted.",
+        description => "Write out a summary json file, if no path is provided 'summary.json' will be used. The .json extension is added automatically if omitted.",
 
         long_examples => ['', '=/path/to/summary.json'],
 

--- a/lib/App/Yath/Options/Debug.pm
+++ b/lib/App/Yath/Options/Debug.pm
@@ -48,7 +48,7 @@ option_group {prefix => 'debug', category => 'Help and Debugging'} => sub {
 
     option summary => (
         type => 'd',
-        description => "Write out a summary json file, if no path is provided 'summary.json' will be used. The .json extention is added automatically if omitted.",
+        description => "Write out a summary json file, if no path is provided 'summary.json' will be used. The .json extension is added automatically if omitted.",
 
         long_examples  => ['', '=/path/to/summary.json'],
 

--- a/lib/App/Yath/Options/Finder.pm
+++ b/lib/App/Yath/Options/Finder.pm
@@ -61,6 +61,16 @@ option_group {prefix => 'finder', category => "Finder Options", builds => 'Test2
         description => "Point at a json file or url which has a hash of relative test filenames as keys, and 'SHORT', 'MEDIUM', or 'LONG' as values. This will override durations listed in the file headers. An exception will be thrown if the durations file or url does not work.",
     );
 
+    option exclude_list => (
+        field => 'exclude_lists',
+        type => 'm',
+
+        long_examples  => [' file.txt', ' http://example.com/exclusions.txt'],
+        short_examples => [' file.txt', ' http://example.com/exclusions.txt'],
+
+        description => "Point at a file or url which has a new line separated list of relative test filenames to exclude from testing",
+    );
+
     option exclude_file => (
         field => 'exclude_files',
         type  => 'm',

--- a/lib/App/Yath/Options/Finder.pm
+++ b/lib/App/Yath/Options/Finder.pm
@@ -61,16 +61,6 @@ option_group {prefix => 'finder', category => "Finder Options", builds => 'Test2
         description => "Point at a json file or url which has a hash of relative test filenames as keys, and 'SHORT', 'MEDIUM', or 'LONG' as values. This will override durations listed in the file headers. An exception will be thrown if the durations file or url does not work.",
     );
 
-    option exclude_list => (
-        field => 'exclude_lists',
-        type => 'm',
-
-        long_examples  => [' file.txt', ' http://example.com/exclusions.txt'],
-        short_examples => [' file.txt', ' http://example.com/exclusions.txt'],
-
-        description => "Point at a file or url which has a new line separated list of relative test filenames to exclude from testing",
-    );
-
     option exclude_file => (
         field => 'exclude_files',
         type  => 'm',
@@ -89,6 +79,16 @@ option_group {prefix => 'finder', category => "Finder Options", builds => 'Test2
         short_examples => [' t/nope.t'],
 
         description => "Exclude a pattern from testing, matched using m/\$PATTERN/",
+    );
+
+    option exclude_list => (
+        field => 'exclude_lists',
+        type => 'm',
+
+        long_examples  => [' file.txt', ' http://example.com/exclusions.txt'],
+        short_examples => [' file.txt', ' http://example.com/exclusions.txt'],
+
+        description => "Point at a file or url which has a new line separated list of test file names to exclude from testing. Starting a line with a '#' will comment it out (for compatibility with Test2::Aggregate list files).",
     );
 
     option default_search => (

--- a/lib/App/Yath/Options/Run.pm
+++ b/lib/App/Yath/Options/Run.pm
@@ -24,7 +24,7 @@ option_group {prefix => 'run', category => "Run Options", builds => 'Test2::Harn
 
     option test_args => (
         type => 'm',
-        description => 'Arguments to pass in as @ARGV for all tests that are run. These can be provided easier using the \'::\' argument seperator.'
+        description => 'Arguments to pass in as @ARGV for all tests that are run. These can be provided easier using the \'::\' argument separator.'
     );
 
     option input => (
@@ -63,7 +63,7 @@ option_group {prefix => 'run', category => "Run Options", builds => 'Test2::Harn
         field       => 'use_stream',
         alt         => ['TAP', '--no-stream'],
         normalize   => sub { $_[0] ? 0 : 1 },
-        description => "The TAP format is lossy and clunky. Test2::Harness normally uses a newer streaming format to receive test results. There are old/legacy tests wh    ere this causes problems, in which case setting --TAP or --no-stream can help."
+        description => "The TAP format is lossy and clunky. Test2::Harness normally uses a newer streaming format to receive test results. There are old/legacy tests where this causes problems, in which case setting --TAP or --no-stream can help."
     );
 
     option fields => (

--- a/lib/App/Yath/Options/Runner.pm
+++ b/lib/App/Yath/Options/Runner.pm
@@ -15,7 +15,7 @@ my $DEFAULT_COVER_ARGS = '-silent,1,+ignore,^t/,+ignore,^t2/,+ignore,^xt,+ignore
 option_group {prefix => 'runner', category => "Runner Options"} => sub {
     option use_fork => (
         alt         => ['fork'],
-        description => "(default: on, except on windows) Normally tests are run by forking, which allows for features like preloading. This will turn off the behavior globally (which is not compatible with preloading). This is slower, it is better to tag misbehaving tests with the '# HARNESS-NO-PRELOAD' coment in their header to disable forking only for those tests.",
+        description => "(default: on, except on windows) Normally tests are run by forking, which allows for features like preloading. This will turn off the behavior globally (which is not compatible with preloading). This is slower, it is better to tag misbehaving tests with the '# HARNESS-NO-PRELOAD' comment in their header to disable forking only for those tests.",
         env_vars => [qw/!T2_NO_FORK T2_HARNESS_FORK !T2_HARNESS_NO_FORK YATH_FORK !YATH_NO_FORK/],
         default     => sub {
             return 0 if IS_WIN32;

--- a/lib/Test2/Harness/Finder.pm
+++ b/lib/Test2/Harness/Finder.pm
@@ -107,7 +107,7 @@ sub add_exclusions_from_lists {
         next unless $content;
 
         for (split(/\r?\n\r?/, $content)) {
-            $self->{+EXCLUDE_FILES}->{$_} = 1 if /^\s*#/;
+            $self->{+EXCLUDE_FILES}->{$_} = 1 unless /^\s*#/;
         };
     }
 }

--- a/lib/Test2/Harness/Finder.pm
+++ b/lib/Test2/Harness/Finder.pm
@@ -16,7 +16,7 @@ use Test2::Harness::Util::HashBase qw{
 
     <durations <maybe_durations +duration_data
 
-    <exclude_files  <exclude_patterns
+    <exclude_files  <exclude_patterns <exclude_lists
 
     <no_long <only_long
 
@@ -83,9 +83,40 @@ sub _pull_durations {
     die "Invalid duration specification: $in";
 }
 
+sub add_exclusions_from_lists {
+    my $self = shift;
+
+    my @lists = ref($self->{+EXCLUDE_LISTS}) eq 'ARRAY' ? @{$self->{+EXCLUDE_LISTS}} : ($self->{+EXCLUDE_LISTS});
+
+    for my $path (@lists) {
+        my $content;
+        if ($path =~ m{^https?://}) {
+            require HTTP::Tiny;
+            my $res = HTTP::Tiny->new()->get($path);
+
+            die "Could not get exclusion lists from '$path'\n$res->{status}: $res->{reason}\n$res->{content}"
+                unless $res->{success};
+
+            $content = $res->{content};
+        }
+        elsif (-f $path) {
+            require Test2::Harness::Util::File;
+            my $f = Test2::Harness::Util::File->new(name => $path);
+            $content = $f->read();
+        }
+        next unless $content;
+
+        for (split(/\r?\n\r?/, $content)) {
+            $self->{+EXCLUDE_FILES}->{$_} = 1 if /^\s*#/;
+        };
+    }
+}
+
 sub find_files {
     my $self = shift;
     my ($plugins, $settings) = @_;
+
+    $self->add_exclusions_from_lists() if $self->{+EXCLUDE_LISTS};
 
     return $self->find_multi_project_files($plugins, $settings) if $self->multi_project;
     return $self->find_project_files($plugins, $settings, $self->search);
@@ -347,7 +378,7 @@ The input argument should be an L<Test2::Harness::Test> instance. This will
 return a list of human readible reasons a test file should be excluded. If the
 file should not be excluded the list will be empty.
 
-This is a utility method that verifies the file is not in ant exclude
+This is a utility method that verifies the file is not in an exclude
 list/pattern. The reasons are provided back in case you need to inform the
 user.
 


### PR DESCRIPTION
Adds an option for exclusion list text files. Hope the changes are in an appropriate style.

The reason I added this is that we are using Test2::Aggregate with file lists and we originally rolled the functionality of skipping aggregated tests in a yath script custom replacement, but the yath script is no longer minimal like it was (and probably subject to change), so a formal option would be quite helpful for cases such as ours.

I only added an integration test, you can bug me to add unit tests if a Finder unit test file is started in the future ;)