### PR TITLE
Allow HARNESS-NO-RETRY

### DIFF
--- a/README
+++ b/README
@@ -410,6 +410,16 @@ RECIPES
       
           ...
 
+  HARNESS-RETRY-n
+
+    This lets you specify a number (minimum n=1) of retries on test failure
+    for a specific test. HARNESS-RETRY-1 means a failing test will be run twice
+    and is equivalent to HARNESS-RETRY.
+
+  HARNESS-NO-RETRY
+
+    Use this to avoid this test being retried regardless of your retry settings.
+
 MODULE DOCS
 
     This section documents the App::Yath module itself.

--- a/README.md
+++ b/README.md
@@ -399,6 +399,16 @@ to mark the test with LONG or MEDIUM in addition to this marker.
 
         ...
 
+### HARNESS-RETRY-n
+
+This lets you specify a number (minimum n=1) of retries on test failure
+for a specific test. HARNESS-RETRY-1 means a failing test will be run twice
+and is equivalent to HARNESS-RETRY.
+
+### HARNESS-NO-RETRY
+
+Use this to avoid this test being retried regardless of your retry settings.
+
 # MODULE DOCS
 
 This section documents the [App::Yath](https://metacpan.org/pod/App%3A%3AYath) module itself.

--- a/lib/App/Yath.pm
+++ b/lib/App/Yath.pm
@@ -676,6 +676,16 @@ to mark the test with LONG or MEDIUM in addition to this marker.
 
 =back
 
+=head3 HARNESS-RETRY-n
+
+This lets you specify a number (minimum n=1) of retries on test failure
+for a specific test. HARNESS-RETRY-1 means a failing test will be run twice
+and is equivalent to HARNESS-RETRY.
+
+=head3 HARNESS-NO-RETRY
+
+Use this to avoid this test being retried regardless of your retry settings.
+
 =head1 MODULE DOCS
 
 This section documents the L<App::Yath> module itself.

--- a/lib/Test2/Harness/TestFile.pm
+++ b/lib/Test2/Harness/TestFile.pm
@@ -259,13 +259,17 @@ sub _scan {
 
         if ($dir eq 'no') {
             my $feature = lc(join '_' => @args);
-            $headers{features}->{$feature} = 0;
+            if ($feature eq 'retry') {
+                $headers{retry} = 0
+            } else {
+                $headers{features}->{$feature} = 0;
+            }
         }
         elsif ($dir eq 'smoke') {
             $headers{features}->{smoke} = 1;
         }
         elsif ($dir eq 'retry') {
-            $headers{retry} = 1 unless @args;
+            $headers{retry} = 1 unless @args || defined $headers{retry};
             for my $arg (@args) {
                 if ($arg =~ m/^\d+$/) {
                     $headers{retry} = int $arg;

--- a/t/unit/Test2/Harness/TestFile.t
+++ b/t/unit/Test2/Harness/TestFile.t
@@ -36,6 +36,7 @@ my $tmp = gen_temp(
     retry5     => "#HARNESS-RETRY 5\n",
     retry_iso  => "#HARNESS-RETRY-ISO\n",
     retry_iso3 => "#HARNESS-RETRY-ISO 3\n",
+    no_retry   => "#HARNESS-NO-RETRY\n",
 
     not_perl     => "#!/usr/bin/bash\n",
     not_env_perl => "#!/usr/bin/env bash\n",
@@ -668,6 +669,11 @@ subtest smoke => sub {
     $task = $retry->queue_item(42);
     is($task->{retry}, 3, "Enabled retry, 1 initital + 3 retries");
     is($task->{retry_isolated}, T(), "isolated retry");
+
+    $retry = $CLASS->new(file => File::Spec->catfile($tmp, 'no_retry'));
+    $task = $retry->queue_item(42);
+    is($task->{retry}, 0, "Retry set to 0");
+    ok(!exists($task->{retry_isolated}), "not isolated");
 };
 
 done_testing;


### PR DESCRIPTION
A directive for per-test max retry count was added, but there was no way to set it to zero or negate it, to exclude tests from retrying despite the `--retry` setting. With this change `HARNESS-NO-RETRY` will achieve that. Some documentation was added.