### PR TITLE
Fix -j option

### DIFF
--- a/lib/Test2/Harness/Runner.pm
+++ b/lib/Test2/Harness/Runner.pm
@@ -405,6 +405,7 @@ sub next {
 
     my $state = $self->state;
 
+    OUTER:
     while (1) {
         if(my $task = $state->next_task()) {
             next unless $task->{stage} eq $self->{+STAGE};
@@ -413,7 +414,7 @@ sub next {
 
         if (my $lock = $self->lock_dispatch) {
             while (1) {
-                next if $state->advance();
+                next OUTER if $state->advance();
                 last;
             }
         }

--- a/t/integration/concurrency.t
+++ b/t/integration/concurrency.t
@@ -46,7 +46,7 @@ yath(
         @order = map { $_->[0] } sort { $a->[1] <=> $b->[1] } @order;
 
 # The first 4 events should be starts since we have 4 concurrent jobs
-# After they start we MUST see and exit before any more can start
+# After they start we MUST see an exit before any more can start
 # Because of IPC timing we cannot be sure of the order of anything else, but we
 # should have 1 more start and 4 more exits in any order.
         like(shift @order, qr/start/, "Item $_ is 'start'") for 0 .. 3;
@@ -60,6 +60,57 @@ yath(
             },
             "Got one more start, and 4 more exits"
         );
+    },
+);
+
+yath(
+    command => 'test',
+    args    => [$dir, '--ext=tx', '-j2'],
+    log     => 1,
+    exit    => 0,
+    test    => sub {
+        my $out = shift;
+        my $log = $out->{log};
+
+        my @order;
+        my @events = $log->poll();
+        while (@events) {
+            if (my $event = shift @events) {
+                my $f = $event->{facet_data};
+
+                if (my $e = $f->{harness_job_exit}) {
+                    push @order => [exit => $e->{stamp}];
+                }
+
+                if (my $l = $f->{harness_job_start}) {
+                    push @order => [start => $l->{stamp}];
+                }
+            }
+
+            # Check for additional events, probably should not have any, but we may hit
+            # a buffering limit in the log reader and need additional polls.
+            push @events => $log->poll;
+        }
+
+# We care about the order in which events happened based on time stamp, not the
+# order in which they were collected, which may be different. Here we will sort
+# based on stamp.
+        @order = map { $_->[0] } sort { $a->[1] <=> $b->[1] } @order;
+
+# The first 2 events should be starts since we have 2 concurrent jobs
+# After they start we MUST see an exit before any more can start.
+# Following that we should either see a start, or, if we want to be generous
+# and assume the first 2 tests happened to finish at approx. the same time,
+# then another exit followed by 2 starts.
+        like(shift @order, qr/start/, "Item $_ is 'start'") for 0 .. 1;
+        like(shift @order, qr/exit/, "Item 2 must be an exit");
+        my $next = shift @order;
+        if ($next =~ /exit/) {
+            like(shift @order, qr/start/, "Item 4 must be a start if 3 was exit");
+            like(shift @order, qr/start/, "Item 5 must be a start if 3 was exit");
+        } else {
+            like($next, qr/start/, "Item 3 must be a start");
+        }
     },
 );
 


### PR DESCRIPTION
Closes #163 

Using the -j option, the first time a task finished, a `$state->advance` was done without a `$state->next_task`, so a parallel thread was essentially lost.

I added a quick test based on the existing one, although it is not nice (it makes an assumption that the tests used cant go from start to exit immediately), so maybe a nicer one should be written?

PS. The -j/jobs nomenclature (instead something like threads/parallel etc) is a bit unfortunate I realized when reading the code, but it was inherited from prove of course ;)