### PR TITLE
Show LAUNCH on -v

### DIFF
--- a/lib/App/Yath/Options/Display.pm
+++ b/lib/App/Yath/Options/Display.pm
@@ -165,10 +165,12 @@ option_group {prefix => 'formatter', category => "Formatter Options"} => sub {
         $settings->formatter->field(formatter => $settings->formatter->qvf ? 'QVF' : 'Test2')
             unless defined $settings->formatter->formatter;
 
+        $settings->formatter->field(show_job_launch => 1)
+            if $settings->display->verbose > 0;
+
         if ($settings->display->verbose > 1) {
-            $settings->formatter->field(show_job_info   => 1);
-            $settings->formatter->field(show_job_launch => 1);
-            $settings->formatter->field(show_run_info   => 1);
+            $settings->formatter->field(show_job_info => 1);
+            $settings->formatter->field(show_run_info => 1);
         }
     };
 };


### PR DESCRIPTION
Closes #166 

The documentation still said `-show_job_launch` should default on `-v`, not just `-vv`, so this was fixed.