### PR TITLE
Fixed - ignore IGNORE and DEFAULT tags on signal check

### DIFF
--- a/lib/Test2/Harness/IPC.pm
+++ b/lib/Test2/Harness/IPC.pm
@@ -63,7 +63,10 @@ sub start {
     $self->check_for_fork();
 
     for my $sig (qw/INT HUP TERM CHLD/) {
-        croak "Signal '$sig' was already set by something else" if defined $SIG{$sig};
+        croak "Signal '$sig' was already set by something else"
+            if defined $SIG{$sig}
+            && $SIG{$sig} ne 'IGNORE'
+            && $SIG{$sig} ne 'DEFAULT';
         $SIG{$sig} = sub { $self->handle_sig($sig) };
     }
 }


### PR DESCRIPTION
perlipc describes the special strings `IGNORE` and `DEFAULT` as signals that should be discarded or that should do their default thing. We should respect these values when checking signal handlers.