### PR TITLE
Fixed - yath shebang set on install

### DIFF
--- a/scripts/yath
+++ b/scripts/yath
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl
 # Do not use warnings/strict, we want to avoid contamination of the
 
 # '-D' and '--dev-lib' MUST be handled well in advance of loading ANYTHING.


### PR DESCRIPTION
When set as `#!/usr/bin/env perl` the install process does not touch the shebang line in the yath script. But people expect the installer to replace it with the Perl used by the installer.

This tiny PR sets shebang on yath to `#!/usr/bin/perl`, which gets replaced by the installer with the correct `perl`.