### PR TITLE
Add integration test for arisdottle ("::")

### DIFF
--- a/t/integration/test.t
+++ b/t/integration/test.t
@@ -246,4 +246,14 @@ if ("$]" >= 5.026) {
     );
 }
 
+yath(
+    command => 'test',
+    args    => [$dir, '--ext=txxx', '::', 'foobar', 'baz' ],
+    exit    => 0,
+    test    => sub {
+        my $out = shift;
+        like($out->{output}, qr{PASSED}, 'Args after arisdottle are added to @ARGV');
+    },
+);
+
 done_testing;

--- a/t/integration/test/pass.txxx
+++ b/t/integration/test/pass.txxx
@@ -1,0 +1,7 @@
+use Test2::V0;
+
+is (scalar @ARGV, 2);
+is ( $ARGV[0], 'foobar');
+is ( $ARGV[1], 'baz');
+
+done_testing();


### PR DESCRIPTION
I messed around with trying to do this in the test scripts, but after a while
I came to the conclusion that I really do want an integration test that really
is testing how yath behaves at the command line. I wanted to do this in the
most realistic way possible, so I've gone this route. It will obviously only
fire under GitHub CI as it stands, but that may be enough to catch any future
regressions.