### PR TITLE
Explicitly close some file handles

### DIFF
--- a/lib/App/Yath/Command/runner.pm
+++ b/lib/App/Yath/Command/runner.pm
@@ -374,6 +374,9 @@ sub update_io {
         my $msg = "$_[0] at $caller[1] line $caller[2] ($caller2[1] line $caller2[2]).\n";
         print $stderr $msg;
         print STDERR $msg;
+        close($out_fh);
+        close($err_fh);
+        close($in_fh) if $in_fh;
         POSIX::_exit(127);
     };
 

--- a/lib/App/Yath/Command/spawn.pm
+++ b/lib/App/Yath/Command/spawn.pm
@@ -180,10 +180,12 @@ sub run {
             sleep 0.2;
         }
     }
+    close($wfh);
 
     $self->clear_sig_handlers();
 
     my $exit = read_line($fh) // die "Could not get exit code";
+    close($fh);
     $exit = parse_exit($exit);
     if ($exit->{sig}) {
         print STDERR "Terminated with signal: $exit->{sig}.\n";

--- a/lib/App/Yath/Tester.pm
+++ b/lib/App/Yath/Tester.pm
@@ -129,6 +129,7 @@ sub yath {
             push @lines => @new;
             print map { chomp($_); "DEBUG: > $_\n" } @new if $debug > 1;
         }
+        close($rh);
     }
     else {
         print "DEBUG: Waiting for $pid\n" if $debug;

--- a/lib/Test2/Harness/Collector.pm
+++ b/lib/Test2/Harness/Collector.pm
@@ -170,6 +170,7 @@ sub process_runner_output {
             stream => Test2::Harness::Util::File::Stream->new(name => File::Spec->catfile($auxdir, $path)),
         };
     }
+    closedir($dh);
 
     for my $file (sort keys %{$self->{+RUNNER_AUX_HANDLES}}) {
         my $data   = $self->{+RUNNER_AUX_HANDLES}->{$file};

--- a/lib/Test2/Harness/Util.pm
+++ b/lib/Test2/Harness/Util.pm
@@ -318,6 +318,7 @@ sub find_libraries {
                 next unless -f $path && $path =~ m/\.pm$/;
                 push @found => [$path, $prefix];
             }
+            closedir($dh);
         }
 
         push @bases => $new_base if @$new_base;

--- a/scripts/yath
+++ b/scripts/yath
@@ -33,6 +33,7 @@ BEGIN {
         if ($no_stat{lc($^O)}) {
             opendir(my $dh, $dir) or die "$!";
             my $key = join ':' => sort readdir($dh);
+            closedir($dh);
             last if $seen{$key}++;
         }
         else {


### PR DESCRIPTION
After updating to v1.000038 from v1.000000 we can start noticing some `Too many open files` issues.
I did a quick review of the change from `v1.000000..v1.000038` and check all new introduced `~open` 
and add an extra explicit close for them