### PR TITLE
Avoid opening too many jobs in the collector. Only parse so many at o…

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 {{$NEXT}}
 
     - Minor no-op code improvement in Runner.pm
+    - Make collector options configurable
+    - Add collector option for max poll events
+    - Add collector option for max open jobs
 
 1.000038  2020-11-02 20:49:12-08:00 America/Los_Angeles
 

--- a/lib/App/Yath/Command/collector.pm
+++ b/lib/App/Yath/Command/collector.pm
@@ -6,6 +6,7 @@ our $VERSION = '1.000039';
 
 use File::Spec;
 
+use App::Yath::Options;
 use App::Yath::Util qw/isolate_stdout/;
 
 use Test2::Harness::Util::JSON qw/decode_json/;
@@ -15,6 +16,12 @@ use Test2::Harness::Run;
 
 use parent 'App::Yath::Command';
 use Test2::Harness::Util::HashBase;
+
+include_options(
+    'App::Yath::Options::Debug',
+    'App::Yath::Options::PreCommand',
+    'App::Yath::Options::Collector',
+);
 
 sub internal_only   { 1 }
 sub summary         { "For internal use only" }
@@ -28,7 +35,7 @@ sub run {
 
     my $fh = isolate_stdout();
 
-    my $settings = Test2::Harness::Settings->new(File::Spec->catfile($dir, 'settings.json'));
+    my $settings = $self->settings;
 
     require(mod2file($collector_class));
 

--- a/lib/App/Yath/Command/collector.pm
+++ b/lib/App/Yath/Command/collector.pm
@@ -6,7 +6,6 @@ our $VERSION = '1.000039';
 
 use File::Spec;
 
-use App::Yath::Options;
 use App::Yath::Util qw/isolate_stdout/;
 
 use Test2::Harness::Util::JSON qw/decode_json/;
@@ -16,12 +15,6 @@ use Test2::Harness::Run;
 
 use parent 'App::Yath::Command';
 use Test2::Harness::Util::HashBase;
-
-include_options(
-    'App::Yath::Options::Debug',
-    'App::Yath::Options::PreCommand',
-    'App::Yath::Options::Collector',
-);
 
 sub internal_only   { 1 }
 sub summary         { "For internal use only" }
@@ -35,7 +28,7 @@ sub run {
 
     my $fh = isolate_stdout();
 
-    my $settings = $self->settings;
+    my $settings = Test2::Harness::Settings->new(File::Spec->catfile($dir, 'settings.json'));
 
     require(mod2file($collector_class));
 

--- a/lib/App/Yath/Command/start.pm
+++ b/lib/App/Yath/Command/start.pm
@@ -35,6 +35,7 @@ include_options(
     'App::Yath::Options::Runner',
     'App::Yath::Options::Workspace',
     'App::Yath::Options::Persist',
+    'App::Yath::Options::Collector',
 );
 
 option_group {prefix => 'runner', category => "Persistent Runner Options"} => sub {

--- a/lib/App/Yath/Command/test.pm
+++ b/lib/App/Yath/Command/test.pm
@@ -61,6 +61,7 @@ include_options(
     'App::Yath::Options::Run',
     'App::Yath::Options::Runner',
     'App::Yath::Options::Workspace',
+    'App::Yath::Options::Collector',
 );
 
 sub MAX_ATTACH() { 1_048_576 }

--- a/lib/App/Yath/Options/Collector.pm
+++ b/lib/App/Yath/Options/Collector.pm
@@ -9,7 +9,7 @@ use App::Yath::Options;
 option_group {prefix => 'collector', category => "Collector Options"} => sub {
     option max_open_jobs => (
         type => 's',
-        description => 'Maximum number of jobs a collector can process at a time, if more jobs are pending their output will be delayed until the earlier jobs have been processed. (Default: 300)',
+        description => 'Maximum number of jobs a collector can process at a time. If more jobs are pending, their output will be delayed until the earlier jobs have been processed. Note that each job needs roughly 2 file descriptors and the standard UNIX process only has access to 1024 descriptors. Exceeding file descriptors will crash this process. You can find your max file handles by running "ulimit -n" (Default: 300)',
         default => 300,
         long_examples  => [' 300'],
         short_examples => [' 300'],

--- a/lib/App/Yath/Options/Collector.pm
+++ b/lib/App/Yath/Options/Collector.pm
@@ -1,0 +1,65 @@
+package App::Yath::Options::Collector;
+use strict;
+use warnings;
+
+our $VERSION = '1.000039';
+
+use App::Yath::Options;
+
+option_group {prefix => 'collector', category => "Collector Options"} => sub {
+    option max_jobs_to_process => (
+        description => 'The maximum number of jobs that the collector can process each loop (Default: 300)',
+        default => 300,
+    );
+};
+
+1;
+
+__END__
+
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+App::Yath::Options::Collector - collector options for Yath.
+
+=head1 DESCRIPTION
+
+This is where the command line options for the collector are defined.
+
+=head1 PROVIDED OPTIONS POD IS AUTO-GENERATED
+
+=head1 SOURCE
+
+The source code repository for Test2-Harness can be found at
+F<http://github.com/Test-More/Test2-Harness/>.
+
+=head1 MAINTAINERS
+
+=over 4
+
+=item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=back
+
+=head1 AUTHORS
+
+=over 4
+
+=item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=back
+
+=head1 COPYRIGHT
+
+Copyright 2020 Chad Granum E<lt>exodist7@gmail.comE<gt>.
+
+This program is free software; you can redistribute it and/or
+modify it under the same terms as Perl itself.
+
+See F<http://dev.perl.org/licenses/>
+
+=cut

--- a/lib/App/Yath/Options/Collector.pm
+++ b/lib/App/Yath/Options/Collector.pm
@@ -7,9 +7,20 @@ our $VERSION = '1.000039';
 use App::Yath::Options;
 
 option_group {prefix => 'collector', category => "Collector Options"} => sub {
-    option max_jobs_to_process => (
-        description => 'The maximum number of jobs that the collector can process each loop (Default: 300)',
+    option max_open_jobs => (
+        type => 's',
+        description => 'Maximum number of jobs a collector can process at a time, if more jobs are pending their output will be delayed until the earlier jobs have been processed. (Default: 300)',
         default => 300,
+        long_examples  => [' 300'],
+        short_examples => [' 300'],
+    );
+
+    option max_poll_events => (
+        type => 's',
+        description => 'Maximum number of events to poll from a job before jumping to the next job. (Default: 1000)',
+        default => 1000,
+        long_examples  => [' 1000'],
+        short_examples => [' 1000'],
     );
 };
 

--- a/lib/Test2/Harness/Util/Queue.pm
+++ b/lib/Test2/Harness/Util/Queue.pm
@@ -43,11 +43,12 @@ sub reset {
 
 sub poll {
     my $self = shift;
+    my $max = shift;
 
     return $self->{+ENDED} if $self->{+ENDED};
 
     $self->{+QH} ||= Test2::Harness::Util::File::JSONL->new(name => $self->{+FILE});
-    my @out = $self->{+QH}->poll_with_index();
+    my @out = $self->{+QH}->poll_with_index( $max ? (max => $max) : () );
 
     $self->{+ENDED} = $out[-1] if @out && !defined($out[-1]->[-1]);
 


### PR DESCRIPTION
…ne time.

Most unix systems limit the number of file handles any one process can
have open at a time to 1024. When the collector gets behind, it may try
to open too many files for completed jobs at once. Limit this with a
constant. They'll be picked up once the ones polled are processed.