### PR TITLE
Two process management fixes

### DIFF
--- a/lib/App/Yath/Command/start.pm
+++ b/lib/App/Yath/Command/start.pm
@@ -100,7 +100,7 @@ sub run {
         stderr => $stderr,
         stdout => $stdout,
 
-        no_set_pgrp => $settings->runner->daemon,
+        no_set_pgrp => !$settings->runner->daemon,
 
         command => [
             $^X, @prof, $settings->harness->script,

--- a/lib/Test2/Harness/Util/IPC.pm
+++ b/lib/Test2/Harness/Util/IPC.pm
@@ -105,7 +105,8 @@ sub _run_cmd_fork {
 
     swap_io(\*STDERR, $stderr, $die) if $stderr;
     swap_io(\*STDOUT, $stdout, $die) if $stdout;
-    $stdin ? swap_io(\*STDIN,  $stdin,  $die) : close(STDIN);
+    swap_io(\*STDIN,  $stdin,  $die) if $stdin;
+    open(STDIN, "<", "/dev/null") if !$stdin;
 
     @$cmd = map { ref($_) eq 'CODE' ? $_->() : $_ } @$cmd;
 


### PR DESCRIPTION
1. The logic for `no_set_pgrp` in the `start` command was reversed, causing it to not be used in the exact situation where it'd be most useful.

2. Avoid `close(STDIN)`. This wasn't causing any _obvious_ problems, but it did mean that some subprocesses could get created with `STDIN` pointing to the `yath` executable or to other unexpected files.