### PR TITLE
Replace last use of "base" with "parent"

### DIFF
--- a/lib/Test2/Formatter/Stream.pm
+++ b/lib/Test2/Formatter/Stream.pm
@@ -16,7 +16,7 @@ use Test2::Harness::Util qw/hub_truth apply_encoding/;
 
 use Test2::Util qw/get_tid ipc_separator/;
 
-use base qw/Test2::Formatter/;
+use parent qw/Test2::Formatter/;
 use Test2::Util::HashBase qw/-io _encoding _no_header _no_numbers _no_diag -stream_id -tb -tb_handles -dir -_pid -_tid -_fh <job_id -ugids/;
 
 BEGIN {

--- a/t/integration/failure_cases/nested_subtest_exception.tx
+++ b/t/integration/failure_cases/nested_subtest_exception.tx
@@ -4,7 +4,7 @@ use Test2::API qw/context/;
 {
     $INC{'My/Event.pm'} = 1;
     package My::Event;
-    use base 'Test2::Event';
+    use parent 'Test2::Event';
 
     use Test2::Util::Facets2Legacy ':ALL';
 


### PR DESCRIPTION
We already depend on parent, but bump it a little to ensure it has support for "-norequire".