### PR TITLE
Fix runtime-suggests line so it works

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -124,14 +124,7 @@ Test2::Plugin::IOEvents   = 0.001001
 HTTP::Tiny::Multipart     = 0.08
 Test2::Plugin::DBIProfile = 0.002002
 Test2::Plugin::Cover      = 0.000025
-
-[DynamicPrereqs]
-:version = 0.018
--delimiter = |
--body = |if ($^O eq 'Win32') {
--body = |    $WriteMakefileArgs{META_MERGE}{'meta-spec'} = { version => 2 };
--body = |    $WriteMakefileArgs{META_MERGE}{prereqs}{runtime}{suggests}{'Win32::Console::ANSI'} = 0;
--body = |}
+Win32::Console::ANSI      = 0
 
 [MakeMaker::Awesome]
 :version = 0.26


### PR DESCRIPTION
It is not possible, given the current features of ExtUtils::MakeMaker, to have dynamic prerequisites using the recommends, suggests or conflicts types. (This is because these get added via the META_ADD or META_MERGE Makefile arguments, and these are ignored for the generation of MYMETA.json.)