### PR TITLE
Color everything under --color

### DIFF
--- a/lib/Test2/Formatter/Test2.pm
+++ b/lib/Test2/Formatter/Test2.pm
@@ -176,7 +176,7 @@ sub init {
     my $use_color = ref($self->{+COLOR}) ? 1 : delete($self->{+COLOR});
     $use_color = $self->{+TTY} unless defined $use_color;
 
-    if ($self->{+TTY} && USE_ANSI_COLOR) {
+    if ($use_color && USE_ANSI_COLOR) {
         $self->{+SHOW_BUFFER} = 1 unless defined $self->{+SHOW_BUFFER};
 
         if ($use_color) {


### PR DESCRIPTION
Not sure I fully grasp the intended logic here but this appears to be the minimum fix for #245 without regressing use without the flag or use with the `--no-color` flag. The logic here could almost certainly be simplified, the nested testing of `$use_color` at least but I feel it's all more complex than it ought to be. Suggestions welcome.