### PR TITLE
Fix Test2::Harness::Runner::Reloader::reset() not to call blocking() …

### DIFF
--- a/lib/Test2/Harness/Runner/Reloader.pm
+++ b/lib/Test2/Harness/Runner/Reloader.pm
@@ -65,8 +65,12 @@ sub reset {
     delete $self->{+PID};
     $self->{+MONITORED} = {};
     $self->{+MONITOR_LOOKUP} = {};
-    $self->{+WATCHER} = USE_INOTIFY ? Linux::Inotify2->new : {};
-    $self->{+WATCHER}->blocking(0);
+    if (USE_INOTIFY) {
+        $self->{+WATCHER} = Linux::Inotify2->new;
+        $self->{+WATCHER}->blocking(0);
+    } else {
+        $self->{+WATCHER} = {};
+    }
     delete $self->{+STAT_LAST_CHECKED};
 }
 


### PR DESCRIPTION
…method in case of no Linux::Inotify2

If Linux::Inotify2 was not installed, tests failed like this:

$ perl -Ilib t/integration/coverage.t
not ok 1 - yath test -It/integration/coverage/lib t/integration/coverage --ext=tx --cover-wr[...]UA6Bt.json -v {
    not ok 1 - Exit Value Check
    # Failed test 'Exit Value Check'
    # at t/integration/coverage.t line 16.
    # +-----+----+-------+
    # | GOT | OP | CHECK |
    # +-----+----+-------+
    # | 256 | eq | 0     |
    # +-----+----+-------+
    # Command = /usr/bin/perl /home/test/fedora/perl-Test2-Harness/Test2-Harness-1.000113/scripts/yath -Dt/integration/coverage/lib -D/home/test/fedora/perl-Test2-Harness/Test2-Harness-1.000113/lib test -I/home/test/fedora/perl-Test2-Harness/Test2-Harness-1.000113/lib -It/integration/coverage/lib t/integration/coverage --ext=tx --cover-write=/tmp/v68HOUA6Bt.json -v
    # Exit = 256
    # ==== Output ====
    # (INTERNAL)     Can't call method "blocking" on unblessed reference at /home/test/fedora/perl-Test2-Harness/Test2-Harness-1.000113/lib/Test2/Harness/Runner/Reloader.pm line 69.
    # (INTERNAL)     Can't call method "blocking" on unblessed reference at /home/test/fedora/perl-Test2-Harness/Test2-Harness-1.000113/lib/Test2/Harness/Runner/Reloader.pm line 69.
    # (INTERNAL)     BEGIN failed--compilation aborted at /home/test/fedora/perl-Test2-Harness/Test2-Harness-1.000113/scripts/yath line 260.
    #
    # No tests were seen!

https://github.com/Test-More/Test2-Harness/issues/247