### PR TITLE
Fix documentation for the command 'failed'

### DIFF
--- a/lib/App/Yath/Command/failed.pm
+++ b/lib/App/Yath/Command/failed.pm
@@ -15,7 +15,7 @@ use App::Yath::Options;
 option brief => (
     prefix => 'display',
     category => 'Display Options',
-    description => 'Show only files that failed, newline separated, no other output. If a file dailed once but passed on a retry it will NOT be shown.',
+    description => 'Show only the files that failed, newline separated, no other output. If a file failed once but passed on a retry it will NOT be shown.',
 );
 
 sub summary { "Replay a test run from an event log" }

--- a/lib/App/Yath/Command/failed.pm
+++ b/lib/App/Yath/Command/failed.pm
@@ -18,7 +18,7 @@ option brief => (
     description => 'Show only the files that failed, newline separated, no other output. If a file failed once but passed on a retry it will NOT be shown.',
 );
 
-sub summary { "Replay a test run from an event log" }
+sub summary { "Show the failed tests from an event log" }
 
 sub group { 'log' }
 
@@ -26,10 +26,10 @@ sub cli_args { "[--] event_log.jsonl[.gz|.bz2] [job1, job2, ...]" }
 
 sub description {
     return <<"    EOT";
-This yath command will re-run the harness against an event log produced by a
-previous test run. The only required argument is the path to the log file,
-which maybe compressed. Any extra arguments are assumed to be job id's. If you
-list any jobs, only listed jobs will be processed.
+This yath command will list the test scripts from an event log that have failed.
+The only required argument is the path to the log file, which may be compressed.
+Any extra arguments are assumed to be job id's. If you list any jobs,
+only the listed jobs will be processed.
 
 This command accepts all the same renderer/formatter options that the 'test'
 command accepts.

--- a/lib/App/Yath/Options.pm
+++ b/lib/App/Yath/Options.pm
@@ -776,7 +776,7 @@ common fields added automatically, this makes it easier to define multiple
 options that share common fields. Common fields can be overridden inside the
 option definition.
 
-These are both equivelent:
+These are both equivalent:
 
     # Using option group
     option_group { category => 'foo', prefix => 'foo' } => sub {

--- a/lib/App/Yath/Options/PreCommand.pm
+++ b/lib/App/Yath/Options/PreCommand.pm
@@ -27,7 +27,7 @@ option_group {prefix => 'harness', pre_command => 1} => sub {
         type => 'b',
 
         category => 'Plugins',
-        description => 'Normally yath scans for and loads all App::Yath::Plugin::* modules in order to bring in command-line options they may provide. This flag will disable that. This is useful if you have a naughty plugin that it loading other modules when it should not.',
+        description => 'Normally yath scans for and loads all App::Yath::Plugin::* modules in order to bring in command-line options they may provide. This flag will disable that. This is useful if you have a naughty plugin that is loading other modules when it should not.',
     );
 
     option project => (


### PR DESCRIPTION
I noticed that the documentation for 'failed' seems to be outdated. Here is a PR that reflects my understanding of 'failed'. Fixed a couple of spelling errors along the way.