### PR TITLE
Avoid Bareword "POSIX::WNOHANG" error in Debug.pm

### DIFF
--- a/lib/App/Yath/Options/Debug.pm
+++ b/lib/App/Yath/Options/Debug.pm
@@ -210,7 +210,7 @@ sub _post_process_interactive {
 
         while(1) {
             $SIG{PIPE} = sub { exit 0 };
-            exit 0 if waitpid($pid, POSIX::WNOHANG);
+            exit 0 if waitpid($pid, &POSIX::WNOHANG);
             exit 0 unless kill(0, $pid);
             my $data = <STDIN>;
             if (defined($data) && length($data)) {


### PR DESCRIPTION
Otherwise you get an error when the code is used on 5.36:
Bareword "POSIX::WNOHANG" not allowed while "strict subs" in use at...