### PR TITLE
Fix use of diag with a zero value.

### DIFF
--- a/lib/Test2/Formatter/Test2/Composer.pm
+++ b/lib/Test2/Formatter/Test2/Composer.pm
@@ -273,7 +273,7 @@ sub render_info {
     my ($f) = @_;
 
     return map {
-        my $details = $_->{details} || '';
+        my $details = $_->{details} // '';
 
         my $msg;
         if (ref($details)) {


### PR DESCRIPTION
Prior to this fix, `diag 0;` would output an empty string instead of "0".

Change from `||` to `//` to only convert undef to the empty string.