### PR TITLE
avoid `my $foo = 1 if $thing`

### DIFF
--- a/lib/App/Yath/Command/runner.pm
+++ b/lib/App/Yath/Command/runner.pm
@@ -428,7 +428,8 @@ sub update_io {
     my $err_fh = open_file($job->err_file, '>');
 
     my $in_file = $job->in_file;
-    my $in_fh = open_file($in_file, '<') if $in_file;
+    my $in_fh;
+    $in_fh = open_file($in_file, '<') if $in_file;
 
     $out_fh->autoflush(1);
     $err_fh->autoflush(1);

--- a/lib/App/Yath/Command/watch.pm
+++ b/lib/App/Yath/Command/watch.pm
@@ -31,7 +31,8 @@ sub run {
 
     my $args     = $self->args;
     shift @$args if @$args && $args->[0] eq '--';
-    my $stop = 1 if @$args && $args->[0] eq 'STOP';
+    my $stop;
+    $stop = 1 if @$args && $args->[0] eq 'STOP';
 
     my $pfile = find_pfile($self->settings, no_fatal => 1)
         or die "No persistent harness was found for the current path.\n";

--- a/lib/App/Yath/Plugin/Cover.pm
+++ b/lib/App/Yath/Plugin/Cover.pm
@@ -205,8 +205,9 @@ sub annotate_event {
     if ($fd->{harness_final}) {
         my $cover      = $settings->cover;
         my $aggregator = $self->{+AGGREGATOR} or return;
-        my $metrics    = $self->metrics($settings) if $cover->metrics;
-        my $final      = $aggregator->finalize();
+        my $metrics;
+        $metrics = $self->metrics($settings) if $cover->metrics;
+        my $final = $aggregator->finalize();
 
         my $percentages = $self->_percentages($metrics);
         my $raw         = join ", ", map { "$_->[0]: $_->[2]/$_->[1] ($_->[3])" } @$percentages;

--- a/lib/Test2/Harness/Finder.pm
+++ b/lib/Test2/Harness/Finder.pm
@@ -220,7 +220,8 @@ sub find_changes {
     my $self = shift;
     my ($plugins, $settings) = @_;
 
-    my @listed_changes = @{$self->{+CHANGED}} if $self->{+CHANGED};
+    my @listed_changes;
+    @listed_changes = @{$self->{+CHANGED}} if $self->{+CHANGED};
 
     my ($type, $diff) = $self->get_diff($plugins, $settings);
 

--- a/lib/Test2/Harness/Runner/Resource/SharedJobSlots.pm
+++ b/lib/Test2/Harness/Runner/Resource/SharedJobSlots.pm
@@ -42,7 +42,8 @@ sub init {
     die "Could not find shared jobs config.\n"
         unless $sconf;
 
-    my $runner_id  = $self->{+RUNNER_ID}  //= $settings->runner->runner_id if $settings->check_prefix('runner');
+    my $runner_id;
+    $runner_id = $self->{+RUNNER_ID} //= $settings->runner->runner_id if $settings->check_prefix('runner');
     my $runner_pid = $self->{+RUNNER_PID} //= $Test2::Harness::Runner::RUNNER_PID // $App::Yath::Command::runner::RUNNER_PID;
 
     my $prefix = $settings->debug->procname_prefix // '';

--- a/lib/Test2/Harness/TestFile.pm
+++ b/lib/Test2/Harness/TestFile.pm
@@ -385,12 +385,13 @@ sub _parse_shbang {
     }xi;
 
     if ($line =~ $shbang_re) {
-        my @switches = grep { m/\S/ } split /\s+/, $1 if defined $1;
+        my @switches;
+        @switches         = grep { m/\S/ } split /\s+/, $1 if defined $1;
         $shbang{switches} = \@switches;
         $shbang{line}     = $line;
     }
     elsif ($line =~ m/^#!/ && $line !~ m/perl/i) {
-        $shbang{line} = $line;
+        $shbang{line}     = $line;
         $shbang{non_perl} = 1;
     }
 

--- a/t/integration/test-w.t
+++ b/t/integration/test-w.t
@@ -1,0 +1,25 @@
+use Test2::V0;
+
+use App::Yath::Tester qw/yath/;
+
+my $dir = __FILE__;
+$dir =~ s{\.t$}{}g;
+$dir =~ s{^\./}{};
+
+# assert that, regardless of order, the `perl -w` shebang only applies
+# to the test file it appears in; see
+# https://github.com/Test-More/Test2-Harness/issues/266
+
+yath(
+    command => 'test',
+    args    => ["$dir/a.tx", "$dir/b.tx", '--ext=tx'],
+    exit    => 0,
+);
+
+yath(
+    command => 'test',
+    args    => ["$dir/b.tx", "$dir/a.tx", '--ext=tx'],
+    exit    => 0,
+);
+
+done_testing;

--- a/t/integration/test-w/a.tx
+++ b/t/integration/test-w/a.tx
@@ -1,0 +1,4 @@
+#!perl -w
+use Test2::V0;
+ok($^W,'-w should be honoured');
+done_testing;

--- a/t/integration/test-w/b.tx
+++ b/t/integration/test-w/b.tx
@@ -1,0 +1,4 @@
+#!perl
+use Test2::V0;
+ok(!$^W,'-w should not leak');
+done_testing;


### PR DESCRIPTION
See https://metacpan.org/dist/perl/view/pod/perldeprecation.pod#Using-my()-in-false-conditional.

Fixes #266 and probably a few more hidden bugs.