### PR TITLE
Fix #293

### DIFF
--- a/lib/Test2/Harness/Collector.pm
+++ b/lib/Test2/Harness/Collector.pm
@@ -543,7 +543,7 @@ sub setup_child_input {
     }
     else {
         my $input = $ts->input // "";
-        my ($fh, $file) = tempfile("input-$$-XXXX", TMPDIR => 1, UNLINK => 1);
+        my ($fh, $file) = tempfile("input-$$-XXXX", TMPDIR => 1, UNLINK => 0);
         print $fh $input;
         close($fh);
         open($fh, '<', $file) or die "Could not open '$file' for reading: $!";


### PR DESCRIPTION
Don't unlink during END for your tempfile when a tempdir is already set to cleanup in END and passed in as the workdir.

Possibly I could be more intelligent about this and maybe check if workdir is *not* matching `^yath-` (set by App::Yath::Tester), but thus far I don't yet see a context where this wouldn't be true, so it just doesn' seem worth checking for.