### PR TITLE
Fix #291 - NULL characters cannot be stored in postgresql

### DIFF
--- a/lib/App/Yath/Schema.pm
+++ b/lib/App/Yath/Schema.pm
@@ -50,6 +50,11 @@ sub is_mariadb {
     return 0;
 }
 
+sub can_store_null_character {
+    return 0 if is_postgresql();
+    return 1;
+}
+
 sub format_uuid_for_db {
     my $class = shift;
     my ($uuid) = @_;

--- a/lib/Test2/Harness/Util/JSON.pm
+++ b/lib/Test2/Harness/Util/JSON.pm
@@ -22,6 +22,7 @@ our @EXPORT_OK = qw{
 
     encode_json_file
     decode_json_file
+    decode_json_no_null
 };
 
 my $json   = Cpanel::JSON::XS->new->utf8(1)->convert_blessed(1)->allow_nonref(1);
@@ -34,6 +35,23 @@ sub encode_pretty_json { my $out; eval { $out = $pretty->encode(@_); 1} // confe
 
 sub json_true  { Cpanel::JSON::XS->true }
 sub json_false { Cpanel::JSON::XS->false }
+
+# It is far easier to strip out null characters before decode.
+sub decode_json_no_null {
+    my $json = shift;
+
+    my $orig = $json;
+    $json =~ s/(?<!\\)((?:\\)(?:0|u0000))/\\$1/g;
+
+    my $out;
+    eval {
+        $out = decode_json($json);
+        1;
+    } and return $out;
+
+    print "Before: $orig\n--------\nAfter: $json\n";
+    exit(1);
+}
 
 sub stream_json_l {
     my ($path, $handler, %params) = @_;

--- a/t/null.t
+++ b/t/null.t
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+
+# This test file verifies Yath handles NULL fine
+# This is also useful for verifying DB's like PostgreSQL which cannot store NULL
+
+use Test2::Bundle::Extended;
+
+use Cpanel::JSON::XS qw/encode_json/;
+
+isnt( "NUL\0", "NUL", "NUL\0 ain't NUL but it is ALSO \0 json:" . encode_json({"\0" => "\0", nest => encode_json({"\0" => "\0"})}) );
+
+done_testing();

--- a/t/unit/Test2/Harness/Util/JSON.t
+++ b/t/unit/Test2/Harness/Util/JSON.t
@@ -1,5 +1,33 @@
 use Test2::V0 -target => 'Test2::Harness::Util::JSON';
 
-skip_all "write me";
+BEGIN {
+    CLASS()->import(qw/decode_json_no_null encode_json encode_pretty_json decode_json/);
+}
+
+subtest decode_json_no_null => sub {
+    my $json = encode_pretty_json({
+        "null\0key" => "null\0\0value",
+        easy        => "null\0\0value",
+        nested      => {
+            value => encode_json({
+                "null\0key"   => "null\0\0value",
+                nested_deeper => encode_json({
+                    "null\0key"        => "null\0\0value",
+                    nested_even_deeper => encode_json({
+                        "null\0key" => "null\0\0value",
+                    }),
+                }),
+            }),
+        }
+    });
+
+    my $orig = decode_json($json);
+    my $parsed = decode_json_no_null($json);
+    my $pretty = encode_pretty_json($parsed);
+
+    is($orig->{nested}, $parsed->{nested}, "Nested item not changed, everything is already escaped");
+    is($orig->{easy}, "null\0\0value", "Null present in original");
+    is($parsed->{easy}, "null\\u0000\\u0000value", "Null escaped in parsed");
+};
 
 done_testing;


### PR DESCRIPTION
@troglodyne I would love your feedback on this fix for the PG null issue.

I tested it with `perl -Ilib scripts/yath -D test --publish-mode complete -v t/null.t --renderer=Server --ephemeral=PostgreSQL` and all seems good. Altering the commit to avoid escapes on PG reintroduces the problem.

This fixes things for PostgreSQL by adding an extra escape to all null characters just before decoding the json when using the run processor and a PostgreSQL database. This does not apply to other databases, but could if any end up with similar behavior.

I chose to escape them instead of stripping them as that makes it more obvious when someone looks at it. I actually suspect we may want to ALWAYS do this so that the null characters are always visible... But not yet.

This will find any \0 or \u0000 that has no escapes (IE the string literal is '\\0' or '\\u0000') And adds an escape. If there is already another escape in front of it then it is not modified, this avoids double-escaping any already escaped, and also will avoid adding escapes to nested json structures.