### PR TITLE
add and respect the --no-final-table display option

### DIFF
--- a/lib/App/Yath/Options/Display.pm
+++ b/lib/App/Yath/Options/Display.pm
@@ -34,6 +34,12 @@ option_group {prefix => 'display', category => "Display Options"} => sub {
         default     => 0,
     );
 
+    option no_final_table => (
+        type        => 'b',
+        description => "When printing final results, don't use table-style display",
+        default     => 0,
+    );
+
     option show_times => (
         short       => 'T',
         description => 'Show the timing data for each job',


### PR DESCRIPTION
At the end of "yath test", you get a summary of the test run in an ASCII art box, which is maybe fine, but it will break up filenames if they're long, like:

    +-------------------------------+
    | filename                      |
    +-------------------------------+
    | t/some-system/important-test- |
    | of-your-code.t                |
    +-------------------------------+

...and then you can't copy the filename from the terminal.  This can be a pain, and the pretty-printing here isn't necessarily getting us much. This commit adds --no-final-table, which affects "yath test", causing it to instead print the final output more like this:

    Failed tests:
    - t/some-system/important-test-of-your-code.t

It still includes job id and subtest information.