### PR TITLE
clear EOF one more time after waitpid

### DIFF
--- a/lib/App/Yath/Tester.pm
+++ b/lib/App/Yath/Tester.pm
@@ -127,6 +127,7 @@ sub yath {
             last;
         }
 
+        seek($rh, 0, SEEK_CUR); # CLEAR EOF
         while (my @new = <$rh>) {
             push @lines => @new;
             print map { chomp($_); "DEBUG: > $_\n" } @new if $debug > 1;


### PR DESCRIPTION
I have very little experience with Perl, so please take the following with a grain of salt.

Once reading from a file has resulted in no data, Perl will remember that there's no more data to be read and will always return no data. This behavior is problematic for the loop polling the file, so a seek operation was used to trick Perl into properly reading the file again.

The problem here is that this is only done in the loop, but not in the code following it. This can lead to the following race condition:
1. The read operation in line 121 returns no data.
    => Perl remembers this.
3. The child writes some data to the file.
4. The child exits.
5. waitpid in line 125 returns that the child has exited.
   => This causes the loop to be exited
7. The code following the loop tries to read the remaining data in line 130, but this never returns any more data because Perl still thinks that there's no more data based on what it remembers from step 1. The result of this is that the data written in step 2 is not observed by the test harness. This causes spurious errors caused by the truncated captured output.

This can be fixed by inserting yet another seek call after the loop to clear the cached EOF result.

This race condition was sometimes causing the "yath help help" subtest and similar other tests to fail. The fix should make these tests a bit more stable.