### PR TITLE
CI: pin cpm retries: 3 on every install step

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -68,10 +68,12 @@ jobs:
         uses: perl-actions/install-with-cpm@v2
         with:
           cpanfile: ".github/cpanfile.ci"
+          retries: 3
       - name: install dependencies from cpanfile
         uses: perl-actions/install-with-cpm@v2
         with:
           cpanfile: "cpanfile"
+          retries: 3
       - run: perl Makefile.PL
       - run: make
       - run: make test
@@ -154,12 +156,14 @@ jobs:
           cpanfile: ".github/cpanfile.ci"
           global: true
           sudo: false
+          retries: 3
       - name: install dependencies from cpanfile
         uses: perl-actions/install-with-cpm@v2
         with:
           cpanfile: "cpanfile"
           global: true
           sudo: false
+          retries: 3
       - run: perl Makefile.PL
       - run: make
       - run: make test


### PR DESCRIPTION
The perl-actions/install-with-cpm action now ships a built-in retry
loop (inputs retries + retry-wait) that absorbs transient upstream
failures from the CPAN mirror, most commonly "599 Internal Exception /
Could not connect to 'cpan.metacpan.org:443': Connection timed out"
(see e.g. run 24878062469). A single such blip was enough to fail the
whole required Simple TestRun job.

Rather than rely on whatever default the upstream action chooses, set
retries: 3 explicitly on all four install steps (ubuntu + matrix, ci +
main cpanfile). That gives up to four attempts with linear backoff per
step, and pins the retry budget in-tree so an upstream default change
cannot quietly make CI more flaky (nor silently mask a genuine outage
by retrying more than we want). retry-wait is left at the upstream
default since the exact value is not load-bearing for us.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
