### PR TITLE
TestFile: Stage B - shebang parsing

### DIFF
--- a/AI_DOCS/2026-04-24-testfile-shebang-stage-b.md
+++ b/AI_DOCS/2026-04-24-testfile-shebang-stage-b.md
@@ -1,0 +1,96 @@
+# TestFile: Stage B — shebang parsing
+
+## What and why
+
+GitHub issue [#376](https://github.com/Test-More/Test2-Harness/issues/376)
+(label `TestFile`, milestone `PTS26`) asked for the second stage of the
+`Test2::Harness2::TestFile` parser: port the legacy `_parse_shbang`
+function and wire it into the line-1 dispatch hole that Stage A (#375)
+left behind.
+
+Until this landed, `switches` stayed at the role default `[]` and
+`non_perl` stayed at `0` for every test file regardless of its shebang.
+Stage H will later use both to decide whether fork / preload are safe —
+they are not, when extra perl switches like `-T` or `-Mblib` are
+present, and preload is nonsensical for `#!/usr/bin/bash` runners.
+
+## What changed
+
+- `lib/Test2/Harness2/TestFile.pm`
+  - Added `_parse_shbang` as a method, verbatim from
+    `reference/legacy/lib/Test2/Harness/TestFile.pm:370-399`. The
+    regex, the `grep { m/\S/ } split /\s+/, $1` tokenizer, and the
+    return shapes (`{line, switches}` / `{line, non_perl}` / `{}`) are
+    preserved byte-for-byte.
+  - Replaced the Stage B placeholder in `_scan` with the line-1
+    dispatch: when `$ln == 1` and the line starts with `#!`, call
+    `_parse_shbang`, store `_shbang`, copy `switches` on a perl
+    shebang, set `non_perl` on a non-perl shebang, and `next`. An
+    empty `{}` return drops through to the ordinary directive path so
+    line-1 non-shebangs still reach HARNESS-* dispatch.
+
+- `t/AI/unit/Harness2/TestFile/shebang.t` (new)
+  - Direct `_parse_shbang` coverage for perl/non-perl/env-perl/env-bash
+    shebangs, `-w`, `-t -w`, `-Mblib`, `undef`, and non-shebang lines.
+  - End-to-end scan coverage for six fixtures: plain perl, `-w`,
+    `env perl -t -w`, bash, no-shebang, `HARNESS-` on line 1.
+
+- `Makefile.PL`
+  - Added `t/AI/unit/Harness2/TestFile/*.t` to the TESTS glob.
+    Stage A's `scan_scaffold.t` and the new `shebang.t` both live
+    under this previously-unlisted subdirectory; without this change
+    `make test` silently skipped them. A regeneration of Makefile.PL
+    from `dist.ini` should keep the new glob entry.
+
+## Decisions
+
+### Verbatim port
+
+The regex `(?: \s (-.+) )?` under `/xi` and the `grep` filter are
+load-bearing against edge cases the legacy test suite documents
+(`#!/usr/bin/env perl -t -w`, `#!/usr/bin/perl -Mblib`,
+`#!/usr/bin/perl` with no switches). Preserving them byte-for-byte
+rules out rewrite regressions.
+
+### Empty-hash guard
+
+`_parse_shbang` returns `{}` when the input is undefined or has no
+`#!`. In `_scan` the dispatch is guarded by `if ($shbang && %$shbang)`
+so that:
+- `_SHBANG` slot is never overwritten with an empty hash,
+- `next` is not triggered for a line that turned out not to be a
+  shebang, so an unusual first line (e.g. `# HARNESS-NO-FORK`) still
+  reaches the directive branches below.
+
+### Slot writes are additive only
+
+- `SWITCHES` is written only when the parse produced a `switches`
+  arrayref (perl shebang) — a non-perl shebang keeps `SWITCHES` at its
+  role default `[]`, never `undef`.
+- `NON_PERL` is only *set to 1*; it is never cleared. The role default
+  is `0`, so no reset is needed.
+
+### Makefile.PL regeneration note
+
+The TESTS glob is maintained by hand (see commit `c98873b20`). Future
+stages that add new subdirectories under `t/AI/unit/Harness2/TestFile/`
+will not need another Makefile.PL entry — the `t/AI/unit/Harness2/TestFile/*.t`
+glob covers every stage's tests that drop into this directory.
+
+## Verification
+
+- `perl -Ilib t/AI/unit/Harness2/TestFile/shebang.t` — 7 subtests pass.
+- `perl -Ilib t/AI/unit/Harness2/TestFile/scan_scaffold.t` — Stage A
+  regression clean.
+- `perl -Ilib t/AI/unit/Harness2/TestFile.t` and
+  `.../Role/TestFile.t` — unaffected, pass.
+- `make test` — 50 files / 481 subtests, all pass (up from 48/469
+  before the TESTS glob update surfaced the TestFile subdir).
+- `perltidy` applied against `.perltidyrc` on both edited files.
+
+## Out of scope (later stages)
+
+- Stage C — binary detection, generated-runner sentinel.
+- Stages D–G — HARNESS-* directive dispatch.
+- Stage H — `check_feature` / `check_duration`, fork/preload
+  suppression when `switches` is non-empty or `non_perl` is truthy.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -149,7 +149,7 @@ my %WriteMakefileArgs = (
   },
   "VERSION" => "2.000011",
   "test" => {
-    "TESTS" => "t/AI/integration/*.t t/AI/unit/*.t t/AI/unit/Collector/*.t t/AI/unit/Collector/Auditor/*.t t/AI/unit/Collector/Parser/*.t t/AI/unit/Collector/Parser/IOParser/*.t t/AI/unit/Harness2/*.t t/AI/unit/Harness2/Collector/Logger/*.t t/AI/unit/Harness2/Collector/Observer/*.t t/AI/unit/Harness2/Resource/*.t t/AI/unit/Harness2/Role/*.t t/AI/unit/Harness2/Role/Collector/*.t t/AI/unit/Harness2/Run/*.t t/AI/unit/Harness2/Util/*.t t/AI/unit/Util/*.t t/AI/unit/Util/File/*.t t/unit/*.t t/unit/Util/*.t t/unit/Util/File/*.t"
+    "TESTS" => "t/AI/integration/*.t t/AI/unit/*.t t/AI/unit/Collector/*.t t/AI/unit/Collector/Auditor/*.t t/AI/unit/Collector/Parser/*.t t/AI/unit/Collector/Parser/IOParser/*.t t/AI/unit/Harness2/*.t t/AI/unit/Harness2/Collector/Logger/*.t t/AI/unit/Harness2/Collector/Observer/*.t t/AI/unit/Harness2/Resource/*.t t/AI/unit/Harness2/Role/*.t t/AI/unit/Harness2/Role/Collector/*.t t/AI/unit/Harness2/Run/*.t t/AI/unit/Harness2/TestFile/*.t t/AI/unit/Harness2/Util/*.t t/AI/unit/Util/*.t t/AI/unit/Util/File/*.t t/unit/*.t t/unit/Util/*.t t/unit/Util/File/*.t"
   }
 );
 

--- a/lib/Test2/Harness2/TestFile.pm
+++ b/lib/Test2/Harness2/TestFile.pm
@@ -60,7 +60,15 @@ sub _scan {
     for (my $ln = 1; my $line = <$fh>; $ln++) {
         next if $line =~ m/^\s*$/;
 
-        # Stage B will parse shebang here when $ln == 1.
+        if ($ln == 1 && $line =~ m/^#!/) {
+            my $shbang = $self->_parse_shbang($line);
+            if ($shbang && %$shbang) {
+                $self->{+_SHBANG}  = $shbang;
+                $self->{+SWITCHES} = $shbang->{switches} if $shbang->{switches};
+                $self->{+NON_PERL} = 1                   if $shbang->{non_perl};
+                next;
+            }
+        }
 
         next if $line =~ m/^\s*\Q$comment\E/ && $line !~ m/^\s*\Q$comment\E\s*HARNESS-.+/;
         next if $line =~ m/^\s*(?:use|require|BEGIN|package)\b/;
@@ -70,6 +78,37 @@ sub _scan {
     }
 
     return;
+}
+
+sub _parse_shbang {
+    my $self = shift;
+    my $line = shift;
+
+    return {} if !defined $line;
+
+    my %shbang;
+
+    # NOTE: dashes are intentionally included with the switches.
+    my $shbang_re = qr{
+        ^
+          \#!.*perl.*?        # the perl path
+          (?: \s (-.+) )?     # the switches, maybe
+          \s*
+        $
+    }xi;
+
+    if ($line =~ $shbang_re) {
+        my @switches;
+        @switches         = grep { m/\S/ } split /\s+/, $1 if defined $1;
+        $shbang{switches} = \@switches;
+        $shbang{line}     = $line;
+    }
+    elsif ($line =~ m/^#!/ && $line !~ m/perl/i) {
+        $shbang{line}     = $line;
+        $shbang{non_perl} = 1;
+    }
+
+    return \%shbang;
 }
 
 1;

--- a/t/AI/unit/Harness2/TestFile/shebang.t
+++ b/t/AI/unit/Harness2/TestFile/shebang.t
@@ -1,0 +1,126 @@
+use Test2::V0;
+use File::Temp qw/tempdir/;
+use File::Spec();
+
+use Test2::Harness2::TestFile;
+
+my $tdir = tempdir(CLEANUP => 1);
+
+sub write_file {
+    my ($path, $content) = @_;
+    open(my $fh, '>', $path) or die "open $path: $!";
+    print {$fh} $content;
+    close($fh);
+    return $path;
+}
+
+sub tf_for {
+    my ($name, $content) = @_;
+    my $path = File::Spec->catfile($tdir, $name);
+    write_file($path, $content);
+    return Test2::Harness2::TestFile->new(file => $path);
+}
+
+# Any constructed TestFile is a valid invocant for _parse_shbang; the
+# tests below use it purely as a method receiver.
+my $invocant = Test2::Harness2::TestFile->new(file => File::Spec->catfile($tdir, 'any.t'));
+write_file($invocant->absolute, '');
+
+subtest '_parse_shbang direct API' => sub {
+    is(
+        $invocant->_parse_shbang("#!/usr/bin/perl\n"),
+        {line => "#!/usr/bin/perl\n", switches => []},
+        'plain perl shebang -> empty switches arrayref',
+    );
+
+    is(
+        $invocant->_parse_shbang("#!/usr/bin/perl -w\n"),
+        {line => "#!/usr/bin/perl -w\n", switches => ['-w']},
+        'single switch',
+    );
+
+    is(
+        $invocant->_parse_shbang("#!/usr/bin/env perl -t -w\n"),
+        {line => "#!/usr/bin/env perl -t -w\n", switches => ['-t', '-w']},
+        'env perl with two switches',
+    );
+
+    is(
+        $invocant->_parse_shbang("#!/usr/bin/perl -Mblib\n"),
+        {line => "#!/usr/bin/perl -Mblib\n", switches => ['-Mblib']},
+        'module switch',
+    );
+
+    is(
+        $invocant->_parse_shbang("#!/usr/bin/bash\n"),
+        {line => "#!/usr/bin/bash\n", non_perl => 1},
+        'plain non-perl shebang -> non_perl flagged, no switches key',
+    );
+
+    is(
+        $invocant->_parse_shbang("#!/usr/bin/env bash\n"),
+        {line => "#!/usr/bin/env bash\n", non_perl => 1},
+        'env bash -> non_perl',
+    );
+
+    is($invocant->_parse_shbang(undef),           {}, 'undef input -> empty hashref');
+    is($invocant->_parse_shbang("use strict;\n"), {}, 'no shebang -> empty hashref');
+};
+
+subtest 'end-to-end scan: #!/usr/bin/perl with no switches' => sub {
+    my $tf = tf_for('plain.t', "#!/usr/bin/perl\nuse strict;\n");
+    $tf->scan;
+    is($tf->switches,                                    [],                  'switches stays empty');
+    is($tf->non_perl,                                    0,                   'non_perl stays 0');
+    is($tf->{+Test2::Harness2::TestFile::_SHBANG}{line}, "#!/usr/bin/perl\n", '_shbang line captured');
+    ok(exists $tf->{+Test2::Harness2::TestFile::_SHBANG}{switches},  '_shbang has switches key');
+    ok(!exists $tf->{+Test2::Harness2::TestFile::_SHBANG}{non_perl}, '_shbang has no non_perl key');
+};
+
+subtest 'end-to-end scan: #!/usr/bin/perl -w populates switches' => sub {
+    my $tf = tf_for('dashw.t', "#!/usr/bin/perl -w\nuse strict;\n");
+    $tf->scan;
+    is($tf->switches, ['-w'], 'switches == [-w]');
+    is($tf->non_perl, 0,      'non_perl stays 0');
+};
+
+subtest 'end-to-end scan: #!/usr/bin/env perl -t -w' => sub {
+    my $tf = tf_for('tw.t', "#!/usr/bin/env perl -t -w\nuse strict;\n");
+    $tf->scan;
+    is($tf->switches, ['-t', '-w'], 'both switches preserved in order');
+    is($tf->non_perl, 0,            'non_perl stays 0');
+};
+
+subtest 'end-to-end scan: #!/usr/bin/bash sets non_perl' => sub {
+    my $tf = tf_for('bash.t', "#!/usr/bin/bash\necho hi\n");
+    $tf->scan;
+    is($tf->switches, [], 'switches stays empty (role default)');
+    is($tf->non_perl, 1,  'non_perl flagged');
+    ok($tf->{+Test2::Harness2::TestFile::_SHBANG}{non_perl}, '_shbang carries non_perl');
+};
+
+subtest 'end-to-end scan: no shebang leaves slots at role defaults' => sub {
+    my $tf = tf_for('noshbang.t', "use strict;\nmy \$x = 1;\n");
+    $tf->scan;
+    is($tf->switches, [], 'switches default []');
+    is($tf->non_perl, 0,  'non_perl default 0');
+    ok(
+               !$tf->{+Test2::Harness2::TestFile::_SHBANG}
+            || !%{$tf->{+Test2::Harness2::TestFile::_SHBANG}},
+        '_shbang is falsy/empty',
+    );
+};
+
+subtest 'end-to-end scan: HARNESS- directive on line 1 is not a shebang' => sub {
+    my $tf = tf_for('directive_first.t', "# HARNESS-NO-FORK\nuse strict;\n");
+    $tf->scan;
+    is($tf->switches, [], 'switches untouched');
+    is($tf->non_perl, 0,  'non_perl untouched');
+    ok(
+               !$tf->{+Test2::Harness2::TestFile::_SHBANG}
+            || !%{$tf->{+Test2::Harness2::TestFile::_SHBANG}},
+        '_shbang remains empty',
+    );
+};
+
+done_testing;


### PR DESCRIPTION
Fix #376

Port _parse_shbang verbatim from reference/legacy (regex, switches
tokenizer, and return shapes preserved byte-for-byte) and wire it into
the Stage A line-1 dispatch hole. On a perl shebang populate SWITCHES
from the parsed switches; on a non-perl shebang set NON_PERL=1;
otherwise drop through to the ordinary directive path so line-1
HARNESS- directives still reach Stage D-G (when they land).

An empty parse return is guarded against: it never overwrites _SHBANG
nor forces `next`, so unusual line-1 content (e.g. `# HARNESS-NO-FORK`
as the very first line) stays on the HARNESS- path.

Adds t/AI/unit/Harness2/TestFile/shebang.t covering _parse_shbang
directly (perl/non-perl/env/bash/undef/no-shebang) and end-to-end via
fixture files for plain perl, -w, env perl -t -w, bash, no-shebang,
and HARNESS- directive on line 1.

Also wires t/AI/unit/Harness2/TestFile/*.t into the Makefile.PL TESTS
glob; this subdirectory was not previously listed, so Stage A's
scan_scaffold.t and the new shebang.t were silently skipped by
`make test`. With the glob entry added, `make test` now runs 50 files
/ 481 subtests (up from 48 / 469), all pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
