### PR TITLE
TestFile: Stage C - binary detection + generated runner sentinel

### DIFF
--- a/AI_DOCS/2026-04-24-testfile-binary-sentinel-stage-c.md
+++ b/AI_DOCS/2026-04-24-testfile-binary-sentinel-stage-c.md
@@ -1,0 +1,145 @@
+# TestFile: Stage C - binary detection + generated-runner sentinel
+
+## What and why
+
+GitHub issue [#377](https://github.com/Test-More/Test2-Harness/issues/377)
+(label `TestFile`, milestone `PTS26`) asked for the third stage of the
+`Test2::Harness2::TestFile` parser: teach `_scan` to recognise two
+file-content edge cases the legacy parser handled.
+
+1. **Binary tests.** Compiled C tests (or anything `-B` reports as
+   binary) cannot be scanned line-by-line.
+2. **Generated yath-runner tests.** Auto-generated wrappers start with a
+   `# THIS IS A GENERATED YATH RUNNER TEST` comment that means "do not
+   run me directly" -- translated to `features->{run} = 0`.
+
+Stages A (#375, `_scan` scaffold) and B (#376, shebang parsing) had
+already set up everything Stage C needed as scaffolding: the
+`_SCANNED++` guard, the `-e $self->{+ABSOLUTE}` short-circuit, the
+`Object::HashBase` slots `<is_binary <non_perl <features`, and the
+`init()` loop that seeds every role-defaulted slot (so `+FEATURES`
+is a real `{}` hashref by the time `_scan` runs, and `{run} = 0`
+autovivifies cleanly).
+
+## What changed
+
+- `lib/Test2/Harness2/TestFile.pm`
+  - Replaced the Stage A placeholder `return if $self->{+IS_BINARY};`
+    with a real detection block at the top of `_scan`:
+
+    ```perl
+    if (-B _ && !-z _) {
+        $self->{+IS_BINARY} = 1;
+        $self->{+NON_PERL}  = 1;
+        return;
+    }
+
+    return if $self->{+IS_BINARY};
+    ```
+
+    The `-B _ && !-z _` reuses the `stat(2)` already cached by the
+    preceding `-e $self->{+ABSOLUTE}` test. The `return if ... IS_BINARY`
+    immediately below is kept for the rehydration case where a
+    `TestFile` is constructed with `is_binary => 1` but no `_scanned`.
+  - Added the generated-runner sentinel branch inside the scan loop,
+    between the shebang block and the comment-skip:
+
+    ```perl
+    if ($line =~ m/^\s*#\s*THIS IS A GENERATED YATH RUNNER TEST/) {
+        $self->{+FEATURES}{run} = 0;
+        next;
+    }
+    ```
+
+    `next`, not `last`: downstream `# HARNESS-*` directives after the
+    sentinel must still be parsed when Stages D-G land.
+
+- `t/AI/unit/Harness2/TestFile/binary_and_generated.t` (new)
+  - 4 subtests covering the binary short-circuit, the `-z` exemption
+    for empty files, the perl-shebang-then-sentinel path (with an
+    extra `lives { scan }` + `_scanned` latch assertion standing in
+    for the `next`-not-`last` proof until Stage F can tighten it with
+    a post-sentinel HARNESS-* directive), and the leading-whitespace
+    regex shape.
+
+The `Makefile.PL` TESTS glob added in Stage B (`t/AI/unit/Harness2/TestFile/*.t`)
+already covers the new file. No Makefile.PL edit was needed.
+
+## Decisions
+
+### Lazy detection in `_scan`, not `init`
+
+Legacy detected binaries in `init()` (`reference/legacy/lib/Test2/Harness/TestFile.pm:77-81`).
+Stage C moves this into `_scan` deliberately, so a `TestFile` rehydrated
+from JSON for a path that no longer exists on disk (or is not yet
+present in the environment) still constructs cleanly; the binary check
+only fires when the harness actually looks at the file.
+
+### `-B _ && !-z _` ordering
+
+The `_` filetest operator reads the stat buffer of the *immediately
+preceding* filetest. The `-e $self->{+ABSOLUTE}` at the top of `_scan`
+populates it; nothing between that line and the binary block may
+perform another `stat(2)` or the cache is lost. This is why the block
+sits right after the `-e` guard.
+
+### No `die` for non-executable binaries
+
+Legacy's `init()` dies with "Cannot run binary test file '$file': file
+is not executable." when `IS_BINARY && !is_executable`. Stage C
+intentionally does **not** carry this over. The new design defers
+run/exec decisions to the runner, not the parser: a `TestFile` is a
+description of what the file says about itself, and it is legitimate
+for the runner to skip an un-runnable file rather than abort parsing.
+This is the only observable deviation from legacy in Stage C. The
+issue defers the final write-up of this deviation to Stage I (when
+the Finder wiring lands), so no `ARCHITECTURE.md` addendum is added
+at this stage.
+
+### `next`, not `last`
+
+The sentinel uses `next` so the rest of the file is still scanned -
+generated wrappers sometimes emit `# HARNESS-CATEGORY-IO` or similar
+after the sentinel, and those must reach the directive-dispatch path
+once Stages D-G land. Stage C cannot assert that those post-sentinel
+directives take effect yet (no dispatch), but a comment in the new
+test file points Stage F at the place to add the stronger assertion.
+
+### Hardcoded `#` in the sentinel regex
+
+The rest of `_scan` uses `\Q$comment\E` to honour a non-`#` comment
+character on non-Perl files. The sentinel regex uses a hardcoded `#`
+because the sentinel is yath-specific and yath only ever generates
+`#`-commented Perl wrappers. This matches legacy
+(`reference/legacy/lib/Test2/Harness/TestFile.pm:256`).
+
+### Kept the `return if $self->{+IS_BINARY}` guard
+
+Even though the new block above already flips `IS_BINARY` from cold,
+the second `return if $self->{+IS_BINARY};` below it is kept as a
+cheap defensive guard: if a caller ever constructs a `TestFile` with
+`is_binary => 1` and `_scanned => 0` (odd but possible under
+rehydration edge cases), the binary-early-out still fires without
+needing to walk through the file-read path.
+
+## Verification
+
+- `perl -Ilib t/AI/unit/Harness2/TestFile/binary_and_generated.t` -
+  5 subtests pass.
+- `perl -Ilib t/AI/unit/Harness2/TestFile.t`,
+  `perl -Ilib t/AI/unit/Harness2/Role/TestFile.t`,
+  `perl -Ilib t/AI/unit/Harness2/TestFile/scan_scaffold.t`,
+  `perl -Ilib t/AI/unit/Harness2/TestFile/shebang.t` - all pass,
+  Stage A and Stage B behaviour unchanged.
+- `make test` - 53 files / 502 subtests, all pass.
+- `perltidy` applied against `.perltidyrc` on both edited files.
+
+## Out of scope (later stages)
+
+- Stages D-G - HARNESS-* directive dispatch (category, duration,
+  stage, fork/preload, conflicts, timeouts, retry).
+- Stage H - `check_feature` / `check_duration` helpers, fork/preload
+  suppression when `switches` is non-empty or `non_perl` is truthy.
+- Stage I - wiring `features->{run} == 0` into Finder filtering, plus
+  the final write-up of the "no `die` for non-executable binaries"
+  deviation from legacy.

--- a/lib/Test2/Harness2/TestFile.pm
+++ b/lib/Test2/Harness2/TestFile.pm
@@ -52,6 +52,13 @@ sub _scan {
 
     return if $self->{+_SCANNED}++;
     return unless -e $self->{+ABSOLUTE};
+
+    if (-B _ && !-z _) {
+        $self->{+IS_BINARY} = 1;
+        $self->{+NON_PERL}  = 1;
+        return;
+    }
+
     return if $self->{+IS_BINARY};
 
     my $comment = $self->{+COMMENT} // '#';
@@ -68,6 +75,11 @@ sub _scan {
                 $self->{+NON_PERL} = 1                   if $shbang->{non_perl};
                 next;
             }
+        }
+
+        if ($line =~ m/^\s*#\s*THIS IS A GENERATED YATH RUNNER TEST/) {
+            $self->{+FEATURES}{run} = 0;
+            next;
         }
 
         next if $line =~ m/^\s*\Q$comment\E/ && $line !~ m/^\s*\Q$comment\E\s*HARNESS-.+/;

--- a/t/AI/unit/Harness2/TestFile/binary_and_generated.t
+++ b/t/AI/unit/Harness2/TestFile/binary_and_generated.t
@@ -1,0 +1,74 @@
+use Test2::V0;
+use File::Temp qw/tempdir/;
+use File::Spec();
+
+use Test2::Harness2::TestFile;
+
+my $tdir = tempdir(CLEANUP => 1);
+
+sub write_file {
+    my ($path, $content) = @_;
+    open(my $fh, '>', $path) or die "open $path: $!";
+    binmode($fh);
+    print {$fh} $content;
+    close($fh);
+    return $path;
+}
+
+sub tf_for {
+    my ($name, $content) = @_;
+    my $path = File::Spec->catfile($tdir, $name);
+    write_file($path, $content);
+    return Test2::Harness2::TestFile->new(file => $path);
+}
+
+subtest 'binary file: _scan short-circuits and flags is_binary + non_perl' => sub {
+    my $bytes = pack 'C*', map { int rand 256 } 1 .. 512;
+    my $tf    = tf_for('bin.t', $bytes);
+
+    $tf->scan;
+
+    is($tf->is_binary, 1,  'is_binary set');
+    is($tf->non_perl,  1,  'non_perl set');
+    is($tf->switches,  [], 'switches untouched (scan short-circuited before shebang)');
+};
+
+subtest 'empty file is not binary (-z exemption)' => sub {
+    my $tf = tf_for('empty.t', '');
+
+    $tf->scan;
+
+    is($tf->is_binary, 0, 'is_binary stays 0');
+    is($tf->non_perl,  0, 'non_perl stays 0');
+};
+
+subtest 'generated runner sentinel sets features->{run} = 0' => sub {
+    # Stage F will tighten the next-vs-last guarantee by appending a
+    # post-sentinel `# HARNESS-*` directive and asserting it took effect
+    # (e.g. category / duration). For Stage C the best we can prove is
+    # that scan() returns cleanly past the sentinel and _scanned latches.
+    my $tf = tf_for(
+        'generated.t',
+        "#!/usr/bin/perl\n" . "# THIS IS A GENERATED YATH RUNNER TEST\n" . "use strict;\n",
+    );
+
+    ok(lives { $tf->scan }, 'scan did not die past the sentinel') or diag($@);
+
+    is($tf->_scanned,       1,  '_scanned latched');
+    is($tf->feature('run'), 0,  'features->{run} set to 0');
+    is($tf->switches,       [], 'shebang branch still ran: switches at role default');
+    is($tf->non_perl,       0,  'perl shebang: non_perl stays 0');
+};
+
+subtest 'sentinel with leading whitespace and spacing still matches' => sub {
+    my $tf = tf_for(
+        'generated_ws.t',
+        "   #   THIS IS A GENERATED YATH RUNNER TEST\n" . "use strict;\n",
+    );
+
+    $tf->scan;
+
+    is($tf->feature('run'), 0, 'features->{run} set to 0');
+};
+
+done_testing;


### PR DESCRIPTION
Fix #377

Lazy binary detection at the top of _scan: once the existing
-e $self->{+ABSOLUTE} guard has cached stat(2) into the _ filetest
buffer, test -B _ && !-z _ and, if true, set IS_BINARY=1, NON_PERL=1
and return without attempting a line-by-line read. The detection sits
in _scan (not init) so a TestFile rehydrated from JSON for a missing
path still constructs. Intentional deviation from legacy: we do not
die when a binary is not executable; run/exec decisions belong to
the runner, not the parser. Final write-up of this deviation is
deferred to Stage I per the issue.

Inside the scan loop, after the Stage B shebang block and before the
comment-skip, recognise the yath-specific sentinel
"# THIS IS A GENERATED YATH RUNNER TEST" and set features->{run} = 0.
Use next, not last, so any downstream # HARNESS-* directive lines
still reach the dispatch path when Stages D-G land. Hardcoded # in
the regex matches legacy; the sentinel is yath-specific and only
emitted into #-commented Perl wrappers. features autovivifies
cleanly because init()'s defaults loop already seeded +FEATURES = {}
in Stage A.

Adds t/AI/unit/Harness2/TestFile/binary_and_generated.t with 5
subtests: a 512-random-byte fixture proves the binary short-circuit,
a zero-byte fixture locks in the !-z exemption, a shebang +
sentinel + use-strict fixture proves features->{run}=0 without
disturbing the Stage B shebang path, a leading-whitespace fixture
pins the ^\s*#\s* regex shape, and a scan-completes-without-error
assertion stands in (with a comment pointing Stage F at the
tightening) for the next-not-last proof.

Stage B's Makefile.PL glob t/AI/unit/Harness2/TestFile/*.t already
picks up the new test file, so no Makefile.PL change was needed.

make test: 53 files / 503 subtests, all pass (up from 50 / 481 at
Stage B baseline). perltidy applied against .perltidyrc.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
