### PR TITLE
TestFile: Stage D - HARNESS-NO/YES/USE directive dispatch

### DIFF
--- a/AI_DOCS/2026-04-24-testfile-directives-stage-d.md
+++ b/AI_DOCS/2026-04-24-testfile-directives-stage-d.md
@@ -1,0 +1,145 @@
+# TestFile: Stage D - HARNESS-NO/YES/USE directive dispatch
+
+## What and why
+
+GitHub issue [#378](https://github.com/Test-More/Test2-Harness/issues/378)
+(label `TestFile`, milestone `PTS26`) asked for the fourth stage of
+the `Test2::Harness2::TestFile` parser: teach `_scan` to dispatch the
+feature-toggle directive family that legacy handles at
+`reference/legacy/lib/Test2/Harness/TestFile.pm:265-307`.
+
+The feature toggles are by far the most-used directive family in
+real-world `.t` files:
+
+- `# HARNESS-NO-FORK`, `# HARNESS-NO-PRELOAD`, `# HARNESS-NO-STREAM`,
+  `# HARNESS-NO-TIMEOUT`, `# HARNESS-NO-IO-EVENTS`, `# HARNESS-NO-RUN`
+- `# HARNESS-USE-ISOLATION`, `# HARNESS-YES-STREAM`
+- `# HARNESS-NO-RETRY` (special-cased into the `retry` attribute, not
+  into `features`)
+
+Before Stage D, every one of these lines reached the placeholder
+comment at the bottom of the `_scan` loop body and fell out of the
+loop on the next iteration, leaving `features` and `retry` untouched.
+
+Stages A-C had already put every prerequisite slot and scaffolding
+piece in place: `<features` and `<retry` are declared on
+`Object::HashBase`, `init()` seeds `+FEATURES = {}` through the
+role-defaults loop, `_scan` captures `HARNESS-(.+)` into `$1` via
+`last unless $line =~ m/^\s*\Q$comment\E\s*HARNESS-(.+)$/` at line 87,
+and `scan()` remains a lazy, caller-driven entry point (not
+auto-invoked from `init()`).
+
+## What changed
+
+- `lib/Test2/Harness2/TestFile.pm`
+  - Replaced the Stage A placeholder
+    `# Stages D-G will dispatch the matched directive here.` at line 89
+    with a verbatim port of legacy's `no` / `yes` / `use` arms.
+  - Port shape: split `$1` on `/[-\s]+/` with limit 2 to peel off the
+    directive word, then normalise the remainder with
+    `s/\s+(?:#.*)?$//` (trailing whitespace / trailing comment) and
+    split it again to collect `@args`. Collapse `@args` to a
+    canonical feature name via `lc(join '_' => @args)`.
+  - `no` arm: `$feature eq 'retry'` routes to `$self->{+RETRY} = 0`,
+    everything else routes to `$self->{+FEATURES}{$feature} = 0`.
+  - `yes` and `use` arms: both set `$self->{+FEATURES}{$feature} = 1`.
+  - `else` arm: `warn "Unknown harness directive ..."`. This is a
+    temporary placeholder for Stages E-G; their directive words
+    (`timeout`, `category`, `duration`, `stage`, `conflicts`, `meta`)
+    will be caught before falling through and the warn branch will
+    naturally stop firing for any legitimate directive.
+
+- `t/AI/unit/Harness2/TestFile/features.t` (new)
+  - Nine subtests, one per directive family from the issue acceptance
+    list, plus a tenth assertion that confirms no `__WARN__` handler
+    saw the unknown-directive message for any valid directive. The
+    subtests assert through the role accessors (`feature`, `features`,
+    `retry`) rather than reaching into the internal hash, so the
+    public surface is what's under test.
+  - Reuses the `write_file` / `tf_for` helper pattern established in
+    Stage B's `shebang.t` and Stage C's `binary_and_generated.t`. The
+    fixtures are minimal: shebang, one HARNESS- line, then a
+    `use strict;` stop-condition that the scan loop's existing
+    `next if $line =~ m/^\s*(?:use|require|BEGIN|package)\b/` picks up.
+
+- `AI_DOCS/2026-04-24-testfile-directives-stage-d.md` (this file).
+
+The `Makefile.PL` TESTS glob `t/AI/unit/Harness2/TestFile/*.t` added
+in Stage B already covers the new test file. No Makefile.PL edit was
+needed.
+
+## Decisions
+
+### Verbatim port of the legacy dispatch
+
+The split-join mechanics in legacy are load-bearing against real-world
+directive lines: trailing inline comments
+(`# HARNESS-NO-FORK  # legacy`), multi-word features
+(`IO-EVENTS` -> `io_events`), whitespace-separated forms
+(`HARNESS NO FORK`). The `/[-\s]+/` alternation for both split passes
+handles all of them. Rewriting the port would risk regressing on
+examples the legacy test corpus already exercises, so Stage D ports
+byte-for-byte and lets Stage H add the validation layer on top.
+
+### `retry` special-case stays inside the `no` arm
+
+Legacy folds the `retry` branch under `no` rather than breaking it out
+as a separate `retry` arm, because the directive line is spelled
+`HARNESS-NO-RETRY` - the user writes "no retry", the parser reads the
+`no` prefix and then asks "is the feature word `retry`?". Mirroring
+that keeps the shape of the code readable against any user writing a
+`.t` file.
+
+### `HARNESS-NO-RETRY` must not leak into `features`
+
+The feature-toggle test covers this explicitly
+(`ok(!exists $tf->features->{retry})`). Without the explicit
+assertion, a regression that dropped the `if/else` inside the `no`
+arm would still pass test 9's `is($tf->retry, 0)` - the autoviv of
+`features->{retry}` would just be invisible. The `!exists` check is
+the guard.
+
+### Temporary `warn` placeholder
+
+Legacy's same `else` branch emits the same warn line. Keeping it here
+until Stages E-G land serves two purposes: it keeps behaviour exactly
+aligned with legacy during the rollout window, and it produces an
+immediate regression signal if Stage E-G add a directive word that
+accidentally falls through to the else. The Stage D test file treats
+a stray warn as a test failure (see the `__WARN__` capture at the
+top), so a regression in the dispatch arms fails loudly rather than
+silently.
+
+### Fixture format: shebang + directive + `use strict;`
+
+Every Stage D fixture is three lines. The shebang keeps the scanner
+on its Perl path (so `non_perl` stays 0 as a side-control); the
+directive line exercises the dispatch; the `use strict;` line is the
+stop-condition the Stage A loop logic expects so the scanner doesn't
+try to read past the directive. This format reuses the same mental
+model Stage B and Stage C fixtures established and keeps the test
+diffs boring.
+
+## Verification
+
+- `perl -Ilib t/AI/unit/Harness2/TestFile/features.t` - 9 subtests +
+  one ward, all pass, no warnings.
+- Stage A-C regression suite
+  (`TestFile.t`, `Role/TestFile.t`, `TestFile/scan_scaffold.t`,
+  `TestFile/shebang.t`, `TestFile/binary_and_generated.t`) - unchanged,
+  all pass.
+- `make test` - 54 files / 512 subtests, all pass (up from Stage C's
+  53 / 502).
+- `perltidy` applied against `.perltidyrc` on both edited files.
+
+## Out of scope (later stages)
+
+- Stages E-G - remaining directive arms (`timeout`, `category`,
+  `duration`, `stage`, `conflicts`, `meta`).
+- Stage H - `check_feature` default table
+  (`reference/legacy/lib/Test2/Harness/TestFile.pm:89-98`), and
+  auto-disable of fork/preload for non-perl tests or tests with
+  extra perl switches.
+- Stage I - Finder wiring for `features->{run}`, and the final
+  write-up of the Stage C "no die for non-executable binaries"
+  deviation.

--- a/lib/Test2/Harness2/TestFile.pm
+++ b/lib/Test2/Harness2/TestFile.pm
@@ -86,7 +86,31 @@ sub _scan {
         next if $line =~ m/^\s*(?:use|require|BEGIN|package)\b/;
         last unless $line =~ m/^\s*\Q$comment\E\s*HARNESS-(.+)$/;
 
-        # Stages D-G will dispatch the matched directive here.
+        my ($dir, $rest) = split /[-\s]+/, $1, 2;
+        $dir = lc($dir);
+        my @args;
+        if ($rest) {
+            $rest =~ s/\s+(?:#.*)?$//;
+            @args = split /[-\s]+/, $rest;
+        }
+
+        if ($dir eq 'no') {
+            my $feature = lc(join '_' => @args);
+            if ($feature eq 'retry') {
+                $self->{+RETRY} = 0;
+            }
+            else {
+                $self->{+FEATURES}{$feature} = 0;
+            }
+        }
+        elsif ($dir eq 'yes' || $dir eq 'use') {
+            my $feature = lc(join '_' => @args);
+            $self->{+FEATURES}{$feature} = 1;
+        }
+        else {
+            # Remaining directive arms land in Stages E-G.
+            warn "Unknown harness directive '$dir' at $self->{+FILE} line $ln.\n";
+        }
     }
 
     return;

--- a/t/AI/unit/Harness2/TestFile/features.t
+++ b/t/AI/unit/Harness2/TestFile/features.t
@@ -1,0 +1,86 @@
+use Test2::V0;
+use File::Temp qw/tempdir/;
+use File::Spec();
+
+use Test2::Harness2::TestFile;
+
+my $tdir = tempdir(CLEANUP => 1);
+
+sub write_file {
+    my ($path, $content) = @_;
+    open(my $fh, '>', $path) or die "open $path: $!";
+    print {$fh} $content;
+    close($fh);
+    return $path;
+}
+
+sub tf_for {
+    my ($name, $directive) = @_;
+    my $path = File::Spec->catfile($tdir, $name);
+    write_file($path, "#!/usr/bin/perl\n" . $directive . "\nuse strict;\n");
+    return Test2::Harness2::TestFile->new(file => $path);
+}
+
+# Scanning must never trip the Stage D fall-through warn for any of
+# the nine valid directives exercised below.
+my @warns;
+local $SIG{__WARN__} = sub { push @warns => $_[0] };
+
+subtest 'HARNESS-NO-TIMEOUT sets features->{timeout} = 0' => sub {
+    my $tf = tf_for('no_timeout.t', '# HARNESS-NO-TIMEOUT');
+    $tf->scan;
+    is($tf->feature('timeout'), 0, 'timeout feature flagged off');
+};
+
+subtest 'HARNESS-NO-FORK sets features->{fork} = 0' => sub {
+    my $tf = tf_for('no_fork.t', '# HARNESS-NO-FORK');
+    $tf->scan;
+    is($tf->feature('fork'), 0, 'fork feature flagged off');
+};
+
+subtest 'HARNESS-NO-PRELOAD sets features->{preload} = 0' => sub {
+    my $tf = tf_for('no_preload.t', '# HARNESS-NO-PRELOAD');
+    $tf->scan;
+    is($tf->feature('preload'), 0, 'preload feature flagged off');
+};
+
+subtest 'HARNESS-NO-STREAM sets features->{stream} = 0' => sub {
+    my $tf = tf_for('no_stream.t', '# HARNESS-NO-STREAM');
+    $tf->scan;
+    is($tf->feature('stream'), 0, 'stream feature flagged off');
+};
+
+subtest 'HARNESS-NO-RUN sets features->{run} = 0' => sub {
+    my $tf = tf_for('no_run.t', '# HARNESS-NO-RUN');
+    $tf->scan;
+    is($tf->feature('run'), 0, 'run feature flagged off');
+};
+
+subtest 'HARNESS-NO-IO-EVENTS collapses to features->{io_events} = 0' => sub {
+    my $tf = tf_for('no_io_events.t', '# HARNESS-NO-IO-EVENTS');
+    $tf->scan;
+    is($tf->feature('io_events'), 0, 'IO-EVENTS collapses to io_events via lc(join _)');
+};
+
+subtest 'HARNESS-USE-ISOLATION sets features->{isolation} = 1' => sub {
+    my $tf = tf_for('use_isolation.t', '# HARNESS-USE-ISOLATION');
+    $tf->scan;
+    is($tf->feature('isolation'), 1, 'isolation feature flagged on');
+};
+
+subtest 'HARNESS-YES-STREAM sets features->{stream} = 1' => sub {
+    my $tf = tf_for('yes_stream.t', '# HARNESS-YES-STREAM');
+    $tf->scan;
+    is($tf->feature('stream'), 1, 'yes arm turns stream on');
+};
+
+subtest 'HARNESS-NO-RETRY is special-cased into retry, not features' => sub {
+    my $tf = tf_for('no_retry.t', '# HARNESS-NO-RETRY');
+    $tf->scan;
+    is($tf->retry, 0, 'retry slot set to 0');
+    ok(!exists $tf->features->{retry}, 'features hash did not receive a retry key');
+};
+
+is(\@warns, [], 'no unknown-directive warnings across any valid NO/YES/USE form');
+
+done_testing;


### PR DESCRIPTION
Fix #378

Port the three feature-toggle arms from reference/legacy (TestFile.pm
lines 265-307) verbatim into the Stage A-C _scan loop, replacing the
"# Stages D-G will dispatch the matched directive here." placeholder
inside _scan with the real dispatch. The $1 capture feeding this
block comes from the existing last-unless regex on the line above and
was already in place; all Stage D needs to do is consume it.

Dispatch mechanics (matching legacy byte-for-byte):
- split /[-\s]+/, $1, 2 peels off the directive word (NO/YES/USE)
  from the argument tail.
- A second split of the tail on the same alternation collects @args,
  after stripping any trailing whitespace or trailing comment.
- lc(join '_' => @args) collapses IO-EVENTS -> io_events so the
  features hash key is canonical.
- The `no` arm routes the special-case feature `retry` into +RETRY
  rather than +FEATURES; everything else goes into +FEATURES = 0.
- The `yes` and `use` arms both set +FEATURES{$feature} = 1.
- The `else` arm warns about unknown directives. This is a temporary
  placeholder for Stages E-G; their directive words (timeout,
  category, duration, stage, conflicts, meta) will match before
  falling through, and the warn will naturally stop firing for any
  legitimate directive once those stages land.

Koan-Bot's planning comment on issue #378 proposes declaring FEATURES
and RETRY on Object::HashBase and calling _scan from init - both are
wrong for the current code state. The slots were already declared in
Stage A, init already seeds +FEATURES = {} via the role-defaults
loop, and scan() is (by design) a lazy caller-driven entry point.

Adds t/AI/unit/Harness2/TestFile/features.t with nine subtests, one
per directive family from the issue acceptance list (NO-TIMEOUT,
NO-FORK, NO-PRELOAD, NO-STREAM, NO-RUN, NO-IO-EVENTS, USE-ISOLATION,
YES-STREAM, NO-RETRY), plus a tenth assertion that guards against
the warn fall-through for any valid directive by installing a
$SIG{__WARN__} capture at file scope. The NO-RETRY test explicitly
checks !exists features->{retry} to prove the retry special-case did
not fall through to the generic features hash.

Stage B's Makefile.PL glob t/AI/unit/Harness2/TestFile/*.t already
picks up the new file; no Makefile.PL change was needed.

make test: 54 files / 512 subtests, all pass (up from Stage C's
53 / 502). perltidy applied against .perltidyrc.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
