### PR TITLE
TestFile: Stage E - HARNESS-SMOKE and HARNESS-RETRY dispatch

### DIFF
--- a/AI_DOCS/2026-04-24-testfile-retry-smoke-stage-e.md
+++ b/AI_DOCS/2026-04-24-testfile-retry-smoke-stage-e.md
@@ -1,0 +1,138 @@
+# TestFile: Stage E - HARNESS-SMOKE + HARNESS-RETRY dispatch
+
+## What and why
+
+GitHub issue [#379](https://github.com/Test-More/Test2-Harness/issues/379)
+(label `TestFile`, milestone `PTS26`) asked for the fifth stage of the
+`Test2::Harness2::TestFile` parser: add the two remaining
+scheduling-affecting directive arms that legacy handles at
+`reference/legacy/lib/Test2/Harness/TestFile.pm:286-302`.
+
+- `# HARNESS-SMOKE` marks a test for elevated scheduler priority. The
+  role's `rank()` helper uses `check_feature('smoke')` to read this.
+- `# HARNESS-RETRY [N] [ISO]` controls retry policy. Forms: bare
+  `RETRY` (retry once), `RETRY N` (retry N times), `RETRY-ISO` (retry
+  once in isolation), `RETRY N ISO` / `RETRY ISO N` (order-insensitive
+  count + isolation).
+
+Stage D already handles `HARNESS-NO-RETRY`. Stage E wires the
+positive / count-bearing retry forms and smoke.
+
+## What changed
+
+- `lib/Test2/Harness2/TestFile.pm`
+  - Added a scan-local `my $retry_set;` before the directive loop. The
+    variable tracks whether any directive has explicitly touched
+    `RETRY` during this scan. It is the substitute for legacy's
+    `defined $headers{retry}` guard, which cannot be used here because
+    `init()`'s defaults loop seeds `$self->{+RETRY} = 0` before `_scan`
+    ever runs, so a `defined` check would always succeed and a bare
+    `# HARNESS-RETRY` would fail to default `retry` to 1.
+  - Wired `$retry_set = 1` into the existing `HARNESS-NO-RETRY` branch
+    inside the `no` arm. This keeps the legacy sticky-NO semantics:
+    `NO-RETRY` followed by a bare `RETRY` leaves retry at 0, because
+    the bare-RETRY path only fires when `!$retry_set`.
+  - Added the `smoke` arm:
+    `$self->{+FEATURES}{smoke} = 1`.
+  - Added the `retry` arm with the full legacy dispatch:
+    - `@args` non-empty: iterate; numeric token sets the count,
+      `iso`-prefixed token flags isolation (and defaults the count to
+      1 only if no count has been set yet this scan), anything else
+      warns.
+    - `@args` empty and `!$retry_set`: default to
+      `$self->{+RETRY} = 1`.
+  - Adjusted the `else`-fall-through warn comment from "Stages E-G"
+    to "Stages F-G".
+
+- `t/AI/unit/Harness2/TestFile/retry_smoke.t` (new)
+  - Nine subtests covering: smoke, bare retry, retry count, retry-ISO
+    (hyphen form), retry-count-ISO, retry-ISO-count (order
+    insensitive), garbage-argument warning, Stage D NO-RETRY then
+    RETRY count override, and multi-line retry where the later count
+    wins. Uses `warnings { ... }` from `Test2::V0` to assert the
+    single expected warning on the garbage case.
+  - Reuses the `write_file` / `tf_for` helper pattern established in
+    Stage B / C / D test files, with `tf_for` now accepting a list of
+    directive lines so multi-directive fixtures (NO-RETRY +
+    RETRY 3, RETRY 2 + RETRY 5) read naturally.
+
+- `AI_DOCS/2026-04-24-testfile-retry-smoke-stage-e.md` (this file).
+
+Stage B's `Makefile.PL` glob `t/AI/unit/Harness2/TestFile/*.t` picks
+up the new test file; no Makefile.PL edit was needed.
+
+## Decisions
+
+### `smoke` lives in `features->{smoke}`, not in a dedicated slot
+
+The issue specifies `features->{smoke} = 1`. Koan-Bot's planning
+comment on the issue argues for a dedicated `SMOKE` attribute, but
+that is wrong for the current concrete class:
+
+- `lib/Test2/Harness2/TestFile.pm:12-24` does **not** declare a
+  `<smoke` slot on `Object::HashBase`. The role documents `smoke` as
+  a typed attribute with a default of 0, but the concrete class never
+  allocates a slot for it.
+- `lib/Test2/Harness2/Role/TestFile.pm:121-125` -- the `rank()`
+  helper -- reads smoke via `$self->check_feature('smoke')`, i.e.
+  from the `features` hashref, not from a dedicated accessor.
+
+Storing smoke in `+FEATURES{smoke}` therefore matches both the legacy
+port target and the only downstream reader that exists today.
+
+### `$retry_set` replaces legacy's `defined` guard
+
+Legacy (`reference/legacy/lib/Test2/Harness/TestFile.pm:289-302`)
+protects the bare-RETRY default with
+`$headers{retry} = 1 unless @args || defined $headers{retry};`.
+Legacy's `%headers` is a scan-local hash, so `$headers{retry}` is
+genuinely undef until a directive touches it.
+
+Our new `_scan` writes directly into `$self->{+RETRY}`, and
+`init()`'s defaults loop seeds `$self->{+RETRY} = 0` before any
+scan runs. A `defined` check would therefore always succeed, breaking
+every bare-RETRY case. Introducing a scan-local `$retry_set` carries
+the same "has a directive touched retry this scan?" semantic without
+disturbing the init-seeding invariant that every other slot relies
+on.
+
+The tracker is also flipped by the Stage D `NO-RETRY` branch, so the
+legacy sticky-NO behaviour is preserved: a bare `RETRY` after a
+`NO-RETRY` does not silently re-enable retries.
+
+### ISO branch's count default uses `unless $retry_set`, not `//=`
+
+Legacy uses `$headers{retry} //= 1` inside the iso branch, relying on
+the same `undef` starting state. For the same reason, that idiom
+would be a no-op here (init seeded 0). The `unless $retry_set` form
+preserves the intent: set retry to 1 only if no count has already
+been recorded this scan.
+
+### Smoke arm is trivially idempotent
+
+Repeated `# HARNESS-SMOKE` lines re-assign the same truthy value to
+the same hash key. No guard needed.
+
+## Verification
+
+- `perl -Ilib t/AI/unit/Harness2/TestFile/retry_smoke.t` - 9 subtests
+  pass.
+- Stage A-D regression suite
+  (`TestFile.t`, `Role/TestFile.t`, `TestFile/scan_scaffold.t`,
+  `TestFile/shebang.t`, `TestFile/binary_and_generated.t`,
+  `TestFile/features.t`) - unchanged, all pass.
+- `make test` - 55 files / 521 subtests, all pass (up from Stage D's
+  54 / 512).
+- `perltidy` applied against `.perltidyrc` on both edited files.
+
+## Out of scope (later stages)
+
+- Stages F-G - remaining directive arms (`timeout`, `category`,
+  `duration`, `stage`, `conflicts`, `meta`).
+- Stage H - `check_feature` default table
+  (`reference/legacy/lib/Test2/Harness/TestFile.pm:89-98`),
+  `check_duration`, `check_category`, and auto-disable of
+  fork/preload for non-perl tests or tests with extra perl switches.
+- Stage I - Finder wiring for `features->{run}` and the final
+  write-up of the Stage C "no die for non-executable binaries"
+  deviation.

--- a/lib/Test2/Harness2/TestFile.pm
+++ b/lib/Test2/Harness2/TestFile.pm
@@ -63,6 +63,7 @@ sub _scan {
 
     my $comment = $self->{+COMMENT} // '#';
 
+    my $retry_set;
     my $fh = open_file($self->{+ABSOLUTE});
     for (my $ln = 1; my $line = <$fh>; $ln++) {
         next if $line =~ m/^\s*$/;
@@ -98,6 +99,7 @@ sub _scan {
             my $feature = lc(join '_' => @args);
             if ($feature eq 'retry') {
                 $self->{+RETRY} = 0;
+                $retry_set = 1;
             }
             else {
                 $self->{+FEATURES}{$feature} = 0;
@@ -107,8 +109,33 @@ sub _scan {
             my $feature = lc(join '_' => @args);
             $self->{+FEATURES}{$feature} = 1;
         }
+        elsif ($dir eq 'smoke') {
+            $self->{+FEATURES}{smoke} = 1;
+        }
+        elsif ($dir eq 'retry') {
+            if (@args) {
+                for my $arg (@args) {
+                    if ($arg =~ m/^\d+$/) {
+                        $self->{+RETRY} = int $arg;
+                        $retry_set = 1;
+                    }
+                    elsif ($arg =~ m/^iso/i) {
+                        $self->{+RETRY}          = 1 unless $retry_set;
+                        $self->{+RETRY_ISOLATED} = 1;
+                        $retry_set               = 1;
+                    }
+                    else {
+                        warn "Unknown 'HARNESS-RETRY' argument '$arg' at $self->{+FILE} line $ln.\n";
+                    }
+                }
+            }
+            elsif (!$retry_set) {
+                $self->{+RETRY} = 1;
+                $retry_set = 1;
+            }
+        }
         else {
-            # Remaining directive arms land in Stages E-G.
+            # Remaining directive arms land in Stages F-G.
             warn "Unknown harness directive '$dir' at $self->{+FILE} line $ln.\n";
         }
     }

--- a/t/AI/unit/Harness2/TestFile/retry_smoke.t
+++ b/t/AI/unit/Harness2/TestFile/retry_smoke.t
@@ -1,0 +1,89 @@
+use Test2::V0;
+use File::Temp qw/tempdir/;
+use File::Spec();
+
+use Test2::Harness2::TestFile;
+
+my $tdir = tempdir(CLEANUP => 1);
+
+sub write_file {
+    my ($path, $content) = @_;
+    open(my $fh, '>', $path) or die "open $path: $!";
+    print {$fh} $content;
+    close($fh);
+    return $path;
+}
+
+sub tf_for {
+    my ($name, @directives) = @_;
+    my $path = File::Spec->catfile($tdir, $name);
+    my $body = "#!/usr/bin/perl\n" . join("\n", @directives) . "\nuse strict;\n";
+    write_file($path, $body);
+    return Test2::Harness2::TestFile->new(file => $path);
+}
+
+subtest 'HARNESS-SMOKE sets features->{smoke} = 1' => sub {
+    my $tf = tf_for('smoke.t', '# HARNESS-SMOKE');
+    $tf->scan;
+    is($tf->feature('smoke'), 1, 'smoke feature flagged on');
+};
+
+subtest 'bare HARNESS-RETRY defaults retry to 1' => sub {
+    my $tf = tf_for('retry_bare.t', '# HARNESS-RETRY');
+    $tf->scan;
+    is($tf->retry,          1, 'retry defaults to 1');
+    is($tf->retry_isolated, 0, 'retry_isolated stays 0');
+};
+
+subtest 'HARNESS-RETRY 3 sets retry count to 3' => sub {
+    my $tf = tf_for('retry_3.t', '# HARNESS-RETRY 3');
+    $tf->scan;
+    is($tf->retry,          3, 'retry count honored');
+    is($tf->retry_isolated, 0, 'retry_isolated stays 0');
+};
+
+subtest 'HARNESS-RETRY-ISO sets retry=1, retry_isolated=1' => sub {
+    my $tf = tf_for('retry_iso.t', '# HARNESS-RETRY-ISO');
+    $tf->scan;
+    is($tf->retry,          1, 'retry defaults to 1 under ISO alone');
+    is($tf->retry_isolated, 1, 'retry_isolated flagged on');
+};
+
+subtest 'HARNESS-RETRY 2 ISO preserves count and flags isolation' => sub {
+    my $tf = tf_for('retry_2_iso.t', '# HARNESS-RETRY 2 ISO');
+    $tf->scan;
+    is($tf->retry,          2, 'explicit count wins');
+    is($tf->retry_isolated, 1, 'retry_isolated flagged on');
+};
+
+subtest 'HARNESS-RETRY ISO 4 is order-insensitive' => sub {
+    my $tf = tf_for('retry_iso_4.t', '# HARNESS-RETRY ISO 4');
+    $tf->scan;
+    is($tf->retry,          4, 'explicit count overrides ISO default');
+    is($tf->retry_isolated, 1, 'retry_isolated flagged on');
+};
+
+subtest 'HARNESS-RETRY garbage warns but does not die' => sub {
+    my $tf       = tf_for('retry_garbage.t', '# HARNESS-RETRY garbage');
+    my $warnings = warnings { $tf->scan };
+    is(scalar @$warnings, 1, 'one warning emitted');
+    like(
+        $warnings->[0],
+        qr/Unknown 'HARNESS-RETRY' argument 'garbage'/,
+        'warning text mentions the unknown argument',
+    );
+};
+
+subtest 'HARNESS-NO-RETRY then HARNESS-RETRY 3 lets the count win' => sub {
+    my $tf = tf_for('no_then_retry.t', '# HARNESS-NO-RETRY', '# HARNESS-RETRY 3');
+    $tf->scan;
+    is($tf->retry, 3, 'explicit count overrides the prior NO-RETRY = 0');
+};
+
+subtest 'Multiple HARNESS-RETRY counts: later value wins' => sub {
+    my $tf = tf_for('retry_twice.t', '# HARNESS-RETRY 2', '# HARNESS-RETRY 5');
+    $tf->scan;
+    is($tf->retry, 5, 'the final explicit count wins');
+};
+
+done_testing;


### PR DESCRIPTION
Fix #379

Port the remaining two scheduling-affecting directive arms from
reference/legacy (TestFile.pm lines 286-302):

- HARNESS-SMOKE -> features->{smoke} = 1. The role's rank() reads
  smoke via check_feature('smoke'), so the features hash is the
  correct storage (no dedicated SMOKE slot exists on the concrete
  class despite Koan-Bot's planning comment).

- HARNESS-RETRY [N] [ISO] -> RETRY count and RETRY_ISOLATED flag.
  The dispatch iterates @args, numeric tokens set the count,
  iso-prefixed tokens flag isolation (defaulting count to 1 only if
  unset this scan), anything else warns. Bare HARNESS-RETRY with no
  args defaults retry to 1 only when nothing has touched it this
  scan.

Why the scan-local $retry_set tracker: legacy's
`$headers{retry} = 1 unless @args || defined $headers{retry}` relies
on $headers{retry} being undef until a directive touches it. Our
init() seeds $self->{+RETRY} = 0 through the defaults loop, so a
`defined` check would always succeed and the bare-RETRY default
would never fire. A scan-local $retry_set carries the same
"explicitly touched this scan" semantic without disturbing the
init-seeding invariant that every other slot relies on. The Stage D
NO-RETRY branch now also flips $retry_set, preserving legacy's
sticky-NO behaviour: a bare RETRY after NO-RETRY does not silently
re-enable retries.

Adds t/AI/unit/Harness2/TestFile/retry_smoke.t with 9 subtests:
smoke, bare retry, RETRY N, RETRY-ISO, RETRY N ISO, RETRY ISO N
(order-insensitive), RETRY garbage (warns), NO-RETRY then RETRY 3
(count overrides), and multi-line RETRY (later count wins). Uses
warnings { ... } from Test2::V0 to catch the single expected
warning. tf_for accepts a list of directive lines so multi-directive
fixtures read naturally.

make test: 55 files / 521 subtests, all pass (up from Stage D's
54 / 512). perltidy applied against .perltidyrc.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
