### PR TITLE
TestFile: Stage F - DURATION / CATEGORY / STAGE dispatch + undef raw defaults

### DIFF
--- a/AI_DOCS/2026-04-24-testfile-category-duration-stage-stage-f.md
+++ b/AI_DOCS/2026-04-24-testfile-category-duration-stage-stage-f.md
@@ -1,0 +1,164 @@
+# TestFile: Stage F - HARNESS-DURATION / HARNESS-CATEGORY / HARNESS-STAGE + raw/derived split
+
+## What and why
+
+GitHub issue [#380](https://github.com/Test-More/Test2-Harness/issues/380)
+(label `TestFile`, milestone `PTS26`) asked for the sixth stage of
+the `Test2::Harness2::TestFile` parser: three scheduling-hint
+directive arms plus a small contract change on the role that makes
+the Stage H `check_category` / `check_duration` fallbacks possible.
+
+Directives landed:
+
+- `# HARNESS-DURATION-LONG` / `# HARNESS-DUR-MEDIUM` -- duration
+  hints used by the Finder's `--no-long` / `--only-long` filters at
+  `lib/App/Yath2/Finder.pm:752-756`. Lowercased.
+- `# HARNESS-CATEGORY-IO` / `# HARNESS-CAT-NETWORK` -- category hints
+  used by the scheduler. Lowercased.
+- `# HARNESS-CATEGORY-LONG` (legacy sugar) -- routed into `duration`
+  rather than `category`, matching legacy at
+  `reference/legacy/lib/Test2/Harness/TestFile.pm:325-330`.
+- `# HARNESS-STAGE-DBStage` -- preload stage name. Case-preserved.
+
+Contract change: `Role::TestFile`'s raw `category` and `duration`
+accessors now default to `undef` (were `'general'` / `'medium'`). The
+raw attribute is the directive-set-or-nothing value; the derived
+`'general'` / `'medium'` fallbacks are what `check_category` /
+`check_duration` already apply on top. Before Stage F the two layers
+were conflated, which made it impossible for Stage H's planned
+`features->{isolation} -> category = 'isolation'` /
+`features->{timeout} off -> duration = 'long'` overrides to
+distinguish "user wrote a directive" from "default". The raw-vs-
+derived split fixes that up-front so Stage H doesn't have to touch
+the scanner again.
+
+## What changed
+
+- `lib/Test2/Harness2/Role/TestFile.pm`
+  - `defaults()` now returns `category => undef, duration => undef`.
+  - The ATTRIBUTES POD explicitly documents the raw-vs-derived
+    contract so future readers understand why the raw accessor
+    returns undef while `check_category` / `check_duration` fall
+    back to `'general'` / `'medium'`.
+
+- `lib/Test2/Harness2/TestFile.pm`
+  - Added three `elsif` arms to the `_scan` directive dispatch,
+    between the Stage E `retry` arm and the Stage G fall-through
+    warn:
+    - `stage` -- case-preserved, stores `$args[0]` directly into
+      `+STAGE`.
+    - `duration` / `dur` -- lowercases `$args[0]` into `+DURATION`.
+    - `category` / `cat` -- lowercases `$args[0]`; if it matches
+      `/^(?:long|medium|short)$/` it routes to `+DURATION` (the
+      legacy "category as duration" sugar), otherwise it sets
+      `+CATEGORY`.
+  - Adjusted the fall-through warn comment from "Stages F-G" to
+    "Stage G" since only that stage remains.
+
+- `t/lib/Test2/Harness2/TestFile.pm`
+  - Removed the `$self->{+CATEGORY} //= 'general'` and
+    `$self->{+DURATION} //= 'medium'` seeds from `init()`. The
+    reference implementation now lets the HashBase accessor return
+    `undef` for an unseeded category/duration slot, matching the new
+    role contract. Every other seed stays in place.
+
+- `t/AI/unit/Harness2/TestFile.t`, `t/AI/unit/Harness2/Role/TestFile.t`,
+  `t/AI/unit/Harness2/TestFile/scan_scaffold.t`
+  - Updated the three existing assertions on the `'general'` /
+    `'medium'` defaults to expect `undef`, including a matching
+    "duration stays undef" pair in the "missing file" subtest of
+    `scan_scaffold.t` (the previous test only checked category).
+
+- `t/AI/unit/Harness2/TestFile/category_duration_stage.t` (new)
+  - Eight subtests covering each directive form from the issue's
+    acceptance list: DURATION-LONG, DUR-SHORT (alias),
+    "DURATION MEDIUM" (space form), CATEGORY-IO, CAT-NETWORK
+    (alias), CATEGORY-LONG (duration sugar), STAGE-DBStage
+    (case preserved), and a "no directive" subtest that locks in
+    the new undef defaults for category / duration / stage.
+  - Reuses the `write_file` / `tf_for` helper pattern established in
+    Stages B-E; `tf_for` from Stage E already accepts a list of
+    directive lines, so multi-directive fixtures are trivial if
+    later stages need them.
+
+- `AI_DOCS/2026-04-24-testfile-category-duration-stage-stage-f.md`
+  (this file).
+
+The concrete `TestFile.pm` was not changed on the HashBase slot list:
+`<category` and `<duration` were already declared in Stage A and the
+`init()` defaults loop already seeds them from `$self->defaults`,
+which now returns `undef` for both. No init logic change was needed
+in the concrete class -- the undef-by-default flow works by itself.
+
+Stage B's `Makefile.PL` glob `t/AI/unit/Harness2/TestFile/*.t` picks
+up the new test file.
+
+## Decisions
+
+### Raw vs derived separation happens here, not in Stage H
+
+Stage H needs three derived fallbacks in `check_category` /
+`check_duration`:
+
+- `features->{isolation}` truthy -> category = `'isolation'`
+- `features->{timeout}` off -> duration = `'long'`
+- Otherwise fall back to the generic `'general'` / `'medium'`.
+
+All three overrides must be able to see that the user did **not**
+write a `HARNESS-CATEGORY-*` / `HARNESS-DURATION-*` directive. The
+cleanest signal is "raw accessor returned undef". Landing the
+undef-raw contract now (one file, three assertion updates) is less
+invasive than landing it together with the Stage H fallback logic
+that will depend on it.
+
+### `category` regex is anchored with the `(?:...)` non-capturing form
+
+Legacy uses `m/^(long|medium|short)$/` with a capturing group that
+is never read. The new form
+`m/^(?:long|medium|short)$/` is identical in behaviour and avoids
+the unused capture. This is the only departure from a byte-for-byte
+port and is a pure readability win.
+
+### Stage name is case-preserved
+
+Legacy (and this stage) does **not** `lc()` the stage name:
+`# HARNESS-STAGE-DBStage` stays `DBStage`. Preload stages are named
+by the user and may be case-sensitive identifiers in the preload
+configuration, so preserving case matters. The dedicated subtest
+`HARNESS-STAGE-DBStage preserves case` locks this in.
+
+### Reference-class init no longer seeds category/duration
+
+`t/lib/Test2/Harness2/TestFile.pm` is the reference implementation
+used by role tests and any caller that wants a drop-in TestFile.
+Before Stage F its `init()` hardcoded `CATEGORY //= 'general'` /
+`DURATION //= 'medium'` to keep the HashBase accessor from returning
+undef. Now that the role contract explicitly allows undef as the
+raw value, those seeds actively contradict the role and the
+`t/AI/unit/Harness2/TestFile.t` "defaults fill in sensibly" subtest
+would fail against the reference class. Removing them keeps the
+reference in sync with the role.
+
+## Verification
+
+- `perl -Ilib t/AI/unit/Harness2/TestFile/category_duration_stage.t`
+  - 8 subtests pass.
+- Stage A-E regression suite (`TestFile.t`, `Role/TestFile.t`,
+  `TestFile/scan_scaffold.t`, `TestFile/shebang.t`,
+  `TestFile/binary_and_generated.t`, `TestFile/features.t`,
+  `TestFile/retry_smoke.t`) -- updated where needed, all pass.
+- `make test` -- 56 files / 529 subtests, all pass (up from Stage
+  E's 55 / 521).
+- `perltidy` applied against `.perltidyrc` on all edited files.
+
+## Out of scope (later stages)
+
+- Stage G - remaining directive arms (`conflicts`, `meta`, the
+  timeout family).
+- Stage H - `check_category` / `check_duration` derived fallbacks
+  (`isolation` / `long` / generic), `check_feature` default table,
+  and auto-disable of fork / preload for non-perl tests or tests
+  with extra perl switches.
+- Stage I - Finder wiring for `features->{run}` and the final
+  write-up of the Stage C "no die for non-executable binaries"
+  deviation.

--- a/lib/Test2/Harness2/Role/TestFile.pm
+++ b/lib/Test2/Harness2/Role/TestFile.pm
@@ -26,8 +26,8 @@ sub defaults {
     return {
         min_slots         => 1,
         max_slots         => undef,
-        category          => 'general',
-        duration          => 'medium',
+        category          => undef,
+        duration          => undef,
         stage             => undef,
         conflicts         => [],
         smoke             => 0,
@@ -120,7 +120,7 @@ my %RANK = (
 
 sub rank {
     my $self = shift;
-    return $RANK{smoke}                  if $self->check_feature('smoke');
+    return $RANK{smoke} if $self->check_feature('smoke');
     return $RANK{$self->check_category} || $RANK{$self->check_duration} || 1;
 }
 
@@ -332,8 +332,12 @@ min_slots" or "as many as are free", per resource).
 
 =item category, duration, stage
 
-Scheduler hints. Defaults: C<category =E<gt> 'general'>, C<duration =E<gt>
-'medium'>, C<stage =E<gt> undef>.
+Scheduler hints. Defaults: C<category =E<gt> undef>, C<duration =E<gt>
+undef>, C<stage =E<gt> undef>. The raw attributes stay undef until a
+C<HARNESS-CATEGORY-*> / C<HARNESS-DURATION-*> / C<HARNESS-STAGE-*>
+directive sets them. The C<check_category> and C<check_duration>
+helpers fall back to C<'general'> / C<'medium'> respectively when the
+raw attribute is still undef.
 
 =item conflicts
 

--- a/lib/Test2/Harness2/TestFile.pm
+++ b/lib/Test2/Harness2/TestFile.pm
@@ -134,8 +134,26 @@ sub _scan {
                 $retry_set = 1;
             }
         }
+        elsif ($dir eq 'stage') {
+            my ($name) = @args;
+            $self->{+STAGE} = $name;
+        }
+        elsif ($dir eq 'duration' || $dir eq 'dur') {
+            my ($name) = @args;
+            $self->{+DURATION} = lc($name);
+        }
+        elsif ($dir eq 'category' || $dir eq 'cat') {
+            my ($name) = @args;
+            $name = lc($name);
+            if ($name =~ m/^(?:long|medium|short)$/) {
+                $self->{+DURATION} = $name;
+            }
+            else {
+                $self->{+CATEGORY} = $name;
+            }
+        }
         else {
-            # Remaining directive arms land in Stages F-G.
+            # Remaining directive arms land in Stage G.
             warn "Unknown harness directive '$dir' at $self->{+FILE} line $ln.\n";
         }
     }

--- a/t/AI/unit/Harness2/Role/TestFile.t
+++ b/t/AI/unit/Harness2/Role/TestFile.t
@@ -65,8 +65,8 @@ subtest 'role provides per-attribute default methods' => sub {
     my $tf = T::Role::TestFile::Bare->new(file => '/x');
     is($tf->min_slots,         1,         'min_slots => 1');
     is($tf->max_slots,         undef,     'max_slots => undef');
-    is($tf->category,          'general', 'category => general');
-    is($tf->duration,          'medium',  'duration => medium');
+    is($tf->category,          undef,     'category => undef (raw default)');
+    is($tf->duration,          undef,     'duration => undef (raw default)');
     is($tf->stage,             undef,     'stage => undef');
     is($tf->conflicts,         [],        'conflicts => []');
     is($tf->smoke,             0,         'smoke => 0');

--- a/t/AI/unit/Harness2/TestFile.t
+++ b/t/AI/unit/Harness2/TestFile.t
@@ -10,8 +10,8 @@ subtest 'defaults fill in sensibly' => sub {
     is($tf->relative,         't/foo.t', 'relative preserved as given');
     is($tf->min_slots,        1,         'min_slots defaults to 1');
     is($tf->max_slots,        undef,     'max_slots defaults to undef');
-    is($tf->category,         'general', 'category default');
-    is($tf->duration,         'medium',  'duration default');
+    is($tf->category,         undef,     'category default (undef until directive sets it)');
+    is($tf->duration,         undef,     'duration default (undef until directive sets it)');
     is([$tf->conflicts_list], [],        'no conflicts by default');
     ok(!$tf->has_conflicts, 'has_conflicts false by default');
     is($tf->features, {}, 'features empty');

--- a/t/AI/unit/Harness2/TestFile/category_duration_stage.t
+++ b/t/AI/unit/Harness2/TestFile/category_duration_stage.t
@@ -1,0 +1,78 @@
+use Test2::V0;
+use File::Temp qw/tempdir/;
+use File::Spec();
+
+use Test2::Harness2::TestFile;
+
+my $tdir = tempdir(CLEANUP => 1);
+
+sub write_file {
+    my ($path, $content) = @_;
+    open(my $fh, '>', $path) or die "open $path: $!";
+    print {$fh} $content;
+    close($fh);
+    return $path;
+}
+
+sub tf_for {
+    my ($name, @directives) = @_;
+    my $path = File::Spec->catfile($tdir, $name);
+    my $body = "#!/usr/bin/perl\n" . join("\n", @directives) . "\nuse strict;\n";
+    write_file($path, $body);
+    return Test2::Harness2::TestFile->new(file => $path);
+}
+
+subtest 'HARNESS-DURATION-LONG sets duration = long' => sub {
+    my $tf = tf_for('dur_long.t', '# HARNESS-DURATION-LONG');
+    $tf->scan;
+    is($tf->duration, 'long', 'duration lowercased to long');
+    is($tf->category, undef,  'category untouched');
+};
+
+subtest 'HARNESS-DUR-SHORT (alias) sets duration = short' => sub {
+    my $tf = tf_for('dur_short.t', '# HARNESS-DUR-SHORT');
+    $tf->scan;
+    is($tf->duration, 'short', 'dur alias accepted');
+};
+
+subtest 'HARNESS-DURATION MEDIUM (space form) sets duration = medium' => sub {
+    my $tf = tf_for('dur_medium.t', '# HARNESS-DURATION MEDIUM');
+    $tf->scan;
+    is($tf->duration, 'medium', 'space-separated form accepted');
+};
+
+subtest 'HARNESS-CATEGORY-IO sets category = io' => sub {
+    my $tf = tf_for('cat_io.t', '# HARNESS-CATEGORY-IO');
+    $tf->scan;
+    is($tf->category, 'io',  'category lowercased to io');
+    is($tf->duration, undef, 'duration untouched');
+};
+
+subtest 'HARNESS-CAT-NETWORK (alias) sets category = network' => sub {
+    my $tf = tf_for('cat_network.t', '# HARNESS-CAT-NETWORK');
+    $tf->scan;
+    is($tf->category, 'network', 'cat alias accepted');
+};
+
+subtest 'HARNESS-CATEGORY-LONG is sugar for HARNESS-DURATION-LONG' => sub {
+    my $tf = tf_for('cat_as_dur.t', '# HARNESS-CATEGORY-LONG');
+    $tf->scan;
+    is($tf->duration, 'long', 'long/medium/short under CATEGORY routed to duration');
+    is($tf->category, undef,  'category stays undef');
+};
+
+subtest 'HARNESS-STAGE-DBStage preserves case' => sub {
+    my $tf = tf_for('stage.t', '# HARNESS-STAGE-DBStage');
+    $tf->scan;
+    is($tf->stage, 'DBStage', 'stage name case-preserved');
+};
+
+subtest 'no directive leaves category / duration / stage undef' => sub {
+    my $tf = tf_for('plain.t');
+    $tf->scan;
+    is($tf->category, undef, 'category undef without directive');
+    is($tf->duration, undef, 'duration undef without directive');
+    is($tf->stage,    undef, 'stage undef without directive');
+};
+
+done_testing;

--- a/t/AI/unit/Harness2/TestFile/scan_scaffold.t
+++ b/t/AI/unit/Harness2/TestFile/scan_scaffold.t
@@ -48,8 +48,8 @@ PERL
     $tf->scan;
     is($opens, 1, 'second scan is a no-op (idempotent)');
 
-    is($tf->category, 'general', 'no dispatch yet: category defaulted');
-    is($tf->duration, 'medium',  'no dispatch yet: duration defaulted');
+    is($tf->category, undef, 'no dispatch yet: category still undef');
+    is($tf->duration, undef, 'no dispatch yet: duration still undef');
     is($tf->features, {},        'no dispatch yet: features empty');
     is($tf->switches, [],        'no dispatch yet: switches empty');
 };
@@ -68,7 +68,8 @@ subtest 'missing file returns silently' => sub {
     my $tf      = Test2::Harness2::TestFile->new(file => $missing);
 
     ok(lives { $tf->scan }, 'scan on missing file lives') or diag $@;
-    is($tf->category, 'general', 'missing file keeps role defaults');
+    is($tf->category, undef, 'missing file keeps role defaults');
+    is($tf->duration, undef, 'missing file keeps role defaults');
 };
 
 subtest 'non-# comment character' => sub {
@@ -101,8 +102,8 @@ subtest 'role defaults intact after scan with no directives' => sub {
 
     is($tf->min_slots,        1,         'min_slots default');
     is($tf->max_slots,        undef,     'max_slots default');
-    is($tf->category,         'general', 'category default');
-    is($tf->duration,         'medium',  'duration default');
+    is($tf->category,         undef,     'category stays undef: no directive seen');
+    is($tf->duration,         undef,     'duration stays undef: no directive seen');
     is($tf->stage,            undef,     'stage default');
     is([$tf->conflicts_list], [],        'conflicts empty');
     is($tf->features,         {},        'features empty');

--- a/t/lib/Test2/Harness2/TestFile.pm
+++ b/t/lib/Test2/Harness2/TestFile.pm
@@ -63,8 +63,6 @@ sub init {
     # HashBase accessor returns the documented default when no value was
     # supplied.
     $self->{+MIN_SLOTS}      //= 1;
-    $self->{+CATEGORY}       //= 'general';
-    $self->{+DURATION}       //= 'medium';
     $self->{+CONFLICTS}      //= [];
     $self->{+SMOKE}          //= 0;
     $self->{+ISOLATION}      //= 0;


### PR DESCRIPTION
Fix #380

Port the three scheduling-hint directive arms from reference/legacy
(TestFile.pm lines 308-330):

- HARNESS-STAGE-<name>  -> +STAGE, case preserved.
- HARNESS-DURATION-<x>  -> +DURATION, lowercased. Alias: HARNESS-DUR-.
- HARNESS-CATEGORY-<x>  -> +CATEGORY, lowercased. Alias: HARNESS-CAT-.
  If the lowercased argument matches /^(?:long|medium|short)$/ it
  routes to +DURATION instead, matching legacy's "category-as-
  duration" sugar.

Also land the raw-vs-derived split for category and duration. The
role's raw accessors now default to undef (were 'general' /
'medium'). Stage H's planned check_category / check_duration
fallbacks need to distinguish "user wrote a directive" from
"default" in order to apply derived overrides
(features->{isolation} -> 'isolation', features->{timeout} off ->
'long'); with the old defaults that distinction was impossible.
check_duration / check_category keep their existing // fallbacks
('medium' / 'general') so public callers see the same derived value
they always did -- only the raw accessor returns undef now.

Aligned changes:

- t/lib/Test2/Harness2/TestFile.pm: dropped the init-time seeds for
  CATEGORY and DURATION so the reference class matches the new role
  contract. Without this the reference class's init would contradict
  the role and role tests would fail against it.

- t/AI/unit/Harness2/TestFile.t,
  t/AI/unit/Harness2/Role/TestFile.t,
  t/AI/unit/Harness2/TestFile/scan_scaffold.t:
  Three existing "category defaults to general / duration defaults
  to medium" assertions updated to expect undef. Added a matching
  "duration stays undef" check in the missing-file subtest of
  scan_scaffold.t (it previously only checked category).

- Role POD now documents the raw-vs-derived contract so future
  readers know why the raw accessor returns undef.

Adds t/AI/unit/Harness2/TestFile/category_duration_stage.t with 8
subtests: DURATION-LONG, DUR-SHORT (alias), "DURATION MEDIUM"
(space-separated form), CATEGORY-IO, CAT-NETWORK (alias),
CATEGORY-LONG (duration sugar), STAGE-DBStage (case-preserved), and
a no-directive subtest locking in the new undef defaults for
category / duration / stage.

make test: 56 files / 529 subtests, all pass (up from Stage E's
55 / 521). perltidy applied against .perltidyrc.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
