### PR TITLE
TestFile: Stage H - derived check_* helpers and fork/preload safety override

### DIFF
--- a/AI_DOCS/2026-04-24-testfile-check-helpers-stage-h.md
+++ b/AI_DOCS/2026-04-24-testfile-check-helpers-stage-h.md
@@ -1,0 +1,161 @@
+# TestFile: Stage H - derived check_* helpers and fork/preload auto-disable
+
+## What and why
+
+GitHub issue [#382](https://github.com/Test-More/Test2-Harness/issues/382)
+(label `TestFile`, milestone `PTS26`) asked for the eighth stage: the
+derived view methods that consumers (notably
+`App::Yath2::Finder::exclude_file` at
+`lib/App/Yath2/Finder.pm:744-756`, and the eventual scheduler) use
+to ask "what should this test's effective timeout / fork / category /
+duration be, applying all the policy fallbacks?".
+
+After Stages A-G every directive populates a raw slot on the
+TestFile, but consumers want a derived view:
+
+- `check_feature(name, default)` -- user's setting, or a per-feature
+  default (`timeout=1, fork=1, preload=1, stream=1, run=1,
+  isolation=0, smoke=0, io_events=1`), or the caller-supplied
+  override.
+- `check_duration` -- user's raw duration, or `'long'` when timeout
+  is disabled, or `'medium'`.
+- `check_category` -- user's raw category, or `'isolation'` when the
+  isolation feature is on, or `'general'`.
+- `check_stage` / `check_min_slots` / `check_max_slots` -- raw
+  slot, or undef.
+
+Stage H also lands the fork/preload safety override from
+`reference/old2/lib/Test2/Harness2/TestFile.pm:418-430`: tests with
+non-perl shebangs, binary files, or perl shebangs carrying any
+switch other than `-w` cannot be forked or preloaded. Putting this
+inside `check_feature('fork')` / `check_feature('preload')` means
+every consumer gets it without opting in. Critically the override
+fires **before** the user's explicit `features->{fork|preload}` is
+consulted -- a user writing `# HARNESS-USE-FORK` on a
+`#!/usr/bin/bash` test still gets `check_feature('fork') == 0`,
+because the runner cannot honour the request.
+
+## What changed
+
+- `lib/Test2/Harness2/TestFile.pm`
+  - Added a file-scope lexical `%DEFAULTS` table with the eight
+    feature defaults ported from
+    `reference/legacy/lib/Test2/Harness/TestFile.pm:89-98`.
+  - Added `check_feature`, `check_duration`, `check_category`,
+    `check_stage`, `check_min_slots`, `check_max_slots` on the
+    concrete class. Each calls `$self->scan` at entry so the helper
+    API makes scan an implicit invariant. `_SCANNED++` in `_scan`
+    keeps the repeated calls idempotent.
+  - `check_feature` implements the fork/preload override before the
+    features-hash lookup. The override checks, in order: non-perl,
+    binary, then iterates `+SWITCHES` and returns 0 as soon as any
+    non-`-w` switch is seen.
+  - `check_duration` and `check_category` use the raw-undef sentinel
+    that Stage F landed to distinguish "user wrote a directive" from
+    "default": a defined raw accessor short-circuits to the user's
+    value before any derived fallback runs.
+
+- `t/AI/unit/Harness2/TestFile/check_helpers.t` (new)
+  - 13 subtests covering: the eight per-feature defaults, the
+    caller-default override, directive-set features, the full
+    duration / category fallback chains, stage/slots pass-through,
+    the fork/preload override matrix (perl-w-only, perl-T,
+    perl-w-Mblib, bash shebang, binary fixture,
+    USE-FORK-beats-safety), and a lazy-scan ward asserting that
+    `check_feature` triggers `_scan` on first call.
+  - Reuses the `write_file` / `tf_for` helper pattern established in
+    Stages B-G; adds a `tf_bytes` sibling for the random-bytes
+    binary fixture (the space-joining `tf_for` cannot produce
+    binary content).
+
+- `AI_DOCS/2026-04-24-testfile-check-helpers-stage-h.md` (this file).
+
+Stage B's `Makefile.PL` glob `t/AI/unit/Harness2/TestFile/*.t` picks
+up the new test file; no Makefile.PL change was needed.
+
+## Decisions
+
+### Helpers live on the concrete class, not the role
+
+The helpers must call `$self->scan`, which is only defined on the
+concrete class. They also read several HashBase slots directly
+(`+NON_PERL`, `+IS_BINARY`, `+SWITCHES`, `+FEATURES`, `+CATEGORY`,
+`+DURATION`, `+STAGE`, `+MIN_SLOTS`, `+MAX_SLOTS`) -- the role has no
+notion of storage, so it can't do that either.
+
+This means the concrete class shadows the role's simpler
+`check_feature` / `check_duration` / `check_category` stubs for
+instances of `Test2::Harness2::TestFile`. The role stubs remain
+available for anyone else consuming the role directly, which is
+fine -- those consumers have their own storage model and their own
+scan (or none), and should override if they want the derived
+behaviour.
+
+### Safety override fires before the features hash
+
+Legacy/old2 put the fork/preload disable in `test_settings()`; Stage
+H moves it inside `check_feature`, as the issue specifies, so no
+caller has to remember to consult a separate gate. The override
+short-circuits **before** consulting `features->{fork|preload}` on
+purpose: user intent (`# HARNESS-USE-FORK`) cannot overrule a
+run-time incompatibility (non-perl shebang, taint mode, etc.). The
+dedicated subtest
+`safety override beats explicit HARNESS-USE-FORK` locks this in.
+
+### `-w` is the one switch that does not disable fork/preload
+
+`-w` toggles warnings and does not require a fresh interpreter, so a
+test using `#!/usr/bin/perl -w` can still run under fork/preload.
+Every other switch (`-T` taint mode, `-Mblib`, `-Ilib/...`, etc.)
+either changes interpreter state in a way a preloaded parent cannot
+carry, or demands interpreter-level behaviour that must be picked up
+at startup. Legacy's old2 treated `-w` as the sole exception; Stage
+H preserves that.
+
+### `%DEFAULTS` is a file-scope lexical
+
+The table is a constant-shaped hash that only `check_feature` reads.
+Keeping it as a `my` lexical (not a package `our` variable) means no
+class outside this file can poke at it and quietly introduce
+consumer-specific defaults. If another module ever wants the same
+table, we'll promote the table at that time, not now.
+
+### `check_feature(undef, ...)` not guarded
+
+The role's stub `check_feature` guards against `undef` feature names
+with `return $default unless defined $name;`. Stage H's richer
+version does not. Calling `check_feature(undef)` at runtime is a
+caller bug (no valid code path passes undef), and guarding against
+it here would mean silently absorbing a bug. Perl's own warning for
+the implicit `$DEFAULTS{undef}` lookup is acceptable noise.
+
+### Lazy scan is a public behaviour change
+
+Before Stage H, consumers had to call `$tf->scan` explicitly before
+reading derived state. Now `check_*` helpers do it themselves. This
+changes the public contract: any consumer that previously relied on
+"I haven't called scan, so the TestFile is at construction-time
+defaults" now sees scanned values once they call `check_*`.
+The trade-off is worth it: every real consumer will either want the
+scanned value, or it will already have called scan itself.
+
+## Verification
+
+- `perl -Ilib t/AI/unit/Harness2/TestFile/check_helpers.t` -- 13
+  subtests pass.
+- Stage A-G regression suite (`TestFile.t`, `Role/TestFile.t`,
+  `TestFile/scan_scaffold.t`, `TestFile/shebang.t`,
+  `TestFile/binary_and_generated.t`, `TestFile/features.t`,
+  `TestFile/retry_smoke.t`, `TestFile/category_duration_stage.t`,
+  `TestFile/timeout_slots_conflicts_meta.t`) -- unchanged, all
+  pass.
+- `make test` -- 58 files / 558 subtests, all pass (up from Stage
+  G's 57 / 545).
+- `perltidy` applied against `.perltidyrc` on both edited files.
+
+## Out of scope (next stage)
+
+- Stage I - wiring Finder to the new `check_*` helpers, porting
+  legacy unit tests for directive coverage, and the final write-up
+  of the Stage C "no die for non-executable binaries" deviation
+  from legacy (deferred from Stage C per the original issue spec).

--- a/lib/Test2/Harness2/TestFile.pm
+++ b/lib/Test2/Harness2/TestFile.pm
@@ -6,7 +6,7 @@ our $VERSION = '2.000011';
 
 use Carp qw/croak/;
 use File::Spec();
-use List::Util qw/uniq/;
+use List::Util qw/any uniq/;
 
 use Test2::Harness2::Util qw/open_file/;
 
@@ -239,6 +239,59 @@ sub _parse_shbang {
 
     return \%shbang;
 }
+
+# Per-feature defaults consulted by check_feature when the caller
+# supplies no explicit default and the user's .t file has no directive
+# touching the feature. Ports reference/legacy/.../TestFile.pm:89-98.
+my %DEFAULTS = (
+    timeout   => 1,
+    fork      => 1,
+    preload   => 1,
+    stream    => 1,
+    run       => 1,
+    isolation => 0,
+    smoke     => 0,
+    io_events => 1,
+);
+
+sub check_feature {
+    my ($self, $feature, $default) = @_;
+    $self->scan;
+    $default = $DEFAULTS{$feature} unless defined $default;
+
+    # Fork and preload cannot be honoured for non-perl / binary tests
+    # or for perl tests with any switch other than -w. The safety
+    # override fires before the user's explicit features->{fork|preload}
+    # is consulted, matching reference/old2/.../TestFile.pm:418-430.
+    if ($feature eq 'fork' || $feature eq 'preload') {
+        return 0 if $self->{+NON_PERL} || $self->{+IS_BINARY};
+        return 0 if any { $_ !~ m/^-w$/ } @{$self->{+SWITCHES} || []};
+    }
+
+    my $set = $self->{+FEATURES}{$feature};
+    return $default unless defined $set;
+    return $set ? 1 : 0;
+}
+
+sub check_duration {
+    my $self = shift;
+    $self->scan;
+    return $self->{+DURATION} if defined $self->{+DURATION};
+    return 'long' unless $self->check_feature('timeout');
+    return 'medium';
+}
+
+sub check_category {
+    my $self = shift;
+    $self->scan;
+    return $self->{+CATEGORY} if defined $self->{+CATEGORY};
+    return 'isolation'        if $self->check_feature('isolation');
+    return 'general';
+}
+
+sub check_stage     { $_[0]->scan; $_[0]->{+STAGE} }
+sub check_min_slots { $_[0]->scan; $_[0]->{+MIN_SLOTS} }
+sub check_max_slots { $_[0]->scan; $_[0]->{+MAX_SLOTS} }
 
 1;
 

--- a/t/AI/unit/Harness2/TestFile/check_helpers.t
+++ b/t/AI/unit/Harness2/TestFile/check_helpers.t
@@ -1,0 +1,175 @@
+use Test2::V0;
+use File::Temp qw/tempdir/;
+use File::Spec();
+
+use Test2::Harness2::TestFile;
+
+my $tdir = tempdir(CLEANUP => 1);
+
+sub write_file {
+    my ($path, $content) = @_;
+    open(my $fh, '>', $path) or die "open $path: $!";
+    binmode($fh);
+    print {$fh} $content;
+    close($fh);
+    return $path;
+}
+
+sub tf_for {
+    my ($name, @lines) = @_;
+    my $path = File::Spec->catfile($tdir, $name);
+    my $body = join("\n", @lines) . "\nuse strict;\n";
+    write_file($path, $body);
+    return Test2::Harness2::TestFile->new(file => $path);
+}
+
+sub tf_bytes {
+    my ($name, $bytes) = @_;
+    my $path = File::Spec->catfile($tdir, $name);
+    write_file($path, $bytes);
+    return Test2::Harness2::TestFile->new(file => $path);
+}
+
+# ---- check_feature: defaults table ----
+
+subtest 'check_feature returns per-feature defaults for untouched features' => sub {
+    my $tf = tf_for('plain.t', '#!/usr/bin/perl');
+    is($tf->check_feature('timeout'),   1, 'timeout default 1');
+    is($tf->check_feature('fork'),      1, 'fork default 1 on plain perl test');
+    is($tf->check_feature('preload'),   1, 'preload default 1 on plain perl test');
+    is($tf->check_feature('stream'),    1, 'stream default 1');
+    is($tf->check_feature('run'),       1, 'run default 1');
+    is($tf->check_feature('io_events'), 1, 'io_events default 1');
+    is($tf->check_feature('isolation'), 0, 'isolation default 0');
+    is($tf->check_feature('smoke'),     0, 'smoke default 0');
+};
+
+subtest 'Explicit default argument overrides the feature table' => sub {
+    my $tf = tf_for('plain.t', '#!/usr/bin/perl');
+    is($tf->check_feature('made_up',   1), 1, 'caller default 1 wins for unknown feature');
+    is($tf->check_feature('made_up',   0), 0, 'caller default 0 wins for unknown feature');
+    is($tf->check_feature('isolation', 1), 1, 'caller default overrides the table default');
+};
+
+subtest 'Directive-set features beat the defaults table' => sub {
+    my $notimeout = tf_for('no_timeout.t', '#!/usr/bin/perl', '# HARNESS-NO-TIMEOUT');
+    is($notimeout->check_feature('timeout'), 0, 'NO-TIMEOUT wins over default 1');
+
+    my $useiso = tf_for('use_iso.t', '#!/usr/bin/perl', '# HARNESS-USE-ISOLATION');
+    is($useiso->check_feature('isolation'), 1, 'USE-ISOLATION wins over default 0');
+};
+
+# ---- check_duration ----
+
+subtest 'check_duration fallback chain' => sub {
+    my $plain = tf_for('plain_d.t', '#!/usr/bin/perl');
+    is($plain->check_duration, 'medium', 'no directive, timeout on -> medium');
+
+    my $no_to = tf_for('no_to_d.t', '#!/usr/bin/perl', '# HARNESS-NO-TIMEOUT');
+    is($no_to->check_duration, 'long', 'NO-TIMEOUT lifts duration to long');
+
+    my $short = tf_for('dur_short.t', '#!/usr/bin/perl', '# HARNESS-DURATION-SHORT');
+    is($short->check_duration, 'short', 'explicit DURATION-SHORT wins');
+
+    my $short_notimeout = tf_for(
+        'short_notimeout.t',        '#!/usr/bin/perl',
+        '# HARNESS-DURATION-SHORT', '# HARNESS-NO-TIMEOUT',
+    );
+    is(
+        $short_notimeout->check_duration,
+        'short',
+        'explicit DURATION still wins when NO-TIMEOUT is also set',
+    );
+};
+
+# ---- check_category ----
+
+subtest 'check_category fallback chain' => sub {
+    my $plain = tf_for('plain_c.t', '#!/usr/bin/perl');
+    is($plain->check_category, 'general', 'no directive -> general');
+
+    my $iso = tf_for('iso_c.t', '#!/usr/bin/perl', '# HARNESS-USE-ISOLATION');
+    is($iso->check_category, 'isolation', 'USE-ISOLATION lifts category to isolation');
+
+    my $cat = tf_for('cat_io.t', '#!/usr/bin/perl', '# HARNESS-CATEGORY-IO');
+    is($cat->check_category, 'io', 'explicit CATEGORY-IO wins');
+
+    my $cat_iso = tf_for(
+        'cat_iso.t',             '#!/usr/bin/perl',
+        '# HARNESS-CATEGORY-IO', '# HARNESS-USE-ISOLATION',
+    );
+    is(
+        $cat_iso->check_category,
+        'io',
+        'explicit CATEGORY still wins when USE-ISOLATION is also set',
+    );
+};
+
+# ---- check_stage / check_min_slots / check_max_slots ----
+
+subtest 'check_stage / check_min_slots / check_max_slots pass-through' => sub {
+    my $plain = tf_for('plain_s.t', '#!/usr/bin/perl');
+    is($plain->check_stage,     undef, 'stage undef without directive');
+    is($plain->check_min_slots, 1,     'min_slots init default is 1');
+    is($plain->check_max_slots, undef, 'max_slots init default is undef');
+
+    my $set = tf_for(
+        'set_s.t',                 '#!/usr/bin/perl',
+        '# HARNESS-STAGE-DBStage', '# HARNESS-JOB-SLOTS 2 4',
+    );
+    is($set->check_stage,     'DBStage', 'stage returned case-preserved');
+    is($set->check_min_slots, 2,         'min_slots returned as stored');
+    is($set->check_max_slots, 4,         'max_slots returned as stored');
+};
+
+# ---- fork / preload safety override ----
+
+subtest 'perl -w only: fork and preload stay enabled' => sub {
+    my $tf = tf_for('dashw.t', '#!/usr/bin/perl -w');
+    is($tf->check_feature('fork'),    1, 'fork still 1 with -w only');
+    is($tf->check_feature('preload'), 1, 'preload still 1 with -w only');
+};
+
+subtest 'perl -T: fork and preload auto-disabled' => sub {
+    my $tf = tf_for('taint.t', '#!/usr/bin/perl -T');
+    is($tf->check_feature('fork'),    0, '-T forces fork off');
+    is($tf->check_feature('preload'), 0, '-T forces preload off');
+};
+
+subtest 'perl -w -Mblib: -Mblib forces fork off even with -w present' => sub {
+    my $tf = tf_for('blib.t', '#!/usr/bin/perl -w -Mblib');
+    is($tf->check_feature('fork'),    0, 'any non-w switch disables fork');
+    is($tf->check_feature('preload'), 0, 'any non-w switch disables preload');
+};
+
+subtest 'bash shebang: fork and preload disabled (non-perl)' => sub {
+    my $tf = tf_for('bash.t', '#!/usr/bin/bash');
+    is($tf->check_feature('fork'),    0, 'non_perl forces fork off');
+    is($tf->check_feature('preload'), 0, 'non_perl forces preload off');
+};
+
+subtest 'binary fixture: fork and preload disabled' => sub {
+    my $bytes = pack 'C*', map { int rand 256 } 1 .. 512;
+    my $tf    = tf_bytes('bin.t', $bytes);
+    is($tf->check_feature('fork'),    0, 'is_binary forces fork off');
+    is($tf->check_feature('preload'), 0, 'is_binary forces preload off');
+};
+
+subtest 'safety override beats explicit HARNESS-USE-FORK' => sub {
+    my $tf = tf_for('bash_usefork.t', '#!/usr/bin/bash', '# HARNESS-USE-FORK');
+    is($tf->check_feature('fork'), 0, 'USE-FORK on non-perl test still returns 0');
+};
+
+# ---- scan is invoked lazily by each check_* ----
+
+subtest 'check_feature triggers scan on first call' => sub {
+    my $tf = tf_for('lazy.t', '#!/usr/bin/perl', '# HARNESS-NO-STREAM');
+
+    # Construct a TestFile but do NOT call scan directly.
+    ok(!$tf->_scanned, '_scanned starts false');
+
+    is($tf->check_feature('stream'), 0, 'check_feature sees directive value');
+    ok($tf->_scanned, '_scanned latched by check_feature');
+};
+
+done_testing;


### PR DESCRIPTION
Fix #382

Add the six derived view helpers that App::Yath2::Finder and the
scheduler depend on, plus the fork/preload auto-disable rule ported
from reference/old2/.../TestFile.pm:418-430.

Helpers landed on the concrete class (they need $self->scan, only
defined there):

- check_feature(name, default): returns the directive-set value, or
  the caller's default, or a per-feature default from the %DEFAULTS
  table (timeout=1, fork=1, preload=1, stream=1, run=1, isolation=0,
  smoke=0, io_events=1) ported from reference/legacy/.../TestFile.pm
  lines 89-98.

- check_duration: raw duration wins; else 'long' when timeout is
  disabled; else 'medium'.

- check_category: raw category wins; else 'isolation' when the
  isolation feature is on; else 'general'. Both rely on the raw-undef
  sentinel that Stage F landed to distinguish "user wrote a
  directive" from "default".

- check_stage / check_min_slots / check_max_slots: raw slot
  pass-through after an implicit scan.

Fork/preload safety override sits inside check_feature and fires
*before* the features hash is consulted. A non-perl shebang, a
binary file, or any shebang switch other than -w forces
check_feature('fork') / check_feature('preload') to 0 even when the
user wrote HARNESS-USE-FORK. Safety overrides user intent because
the runner cannot honour the request -- this matches old2 behaviour
exactly.

Each check_* calls $self->scan on entry, turning scan into a lazy
invariant. _SCANNED++ keeps repeat calls free. A subtle but
deliberate public contract change: consumers that used to rely on
"I haven't scanned, so attributes are at construction defaults"
will now see scanned values once they call check_*.

Adds t/AI/unit/Harness2/TestFile/check_helpers.t with 13 subtests:
the 8 per-feature defaults, caller-default override, directive-set
features, both fallback chains for duration and category,
stage/slots pass-through, the full fork/preload override matrix
(perl -w only, perl -T, perl -w -Mblib, bash shebang, binary
fixture, USE-FORK-beats-safety), and a lazy-scan ward asserting
check_feature flips _scanned on first call.

make test: 58 files / 558 subtests, all pass (up from Stage G's
57 / 545). perltidy applied against .perltidyrc.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
