### PR TITLE
Relax AI_DOCS policy to target durable context only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,15 +20,27 @@ If you're about to implement something that seems to conflict with `ARCHITECTURE
 
 ## AI task documentation
 
-Whenever an AI-assisted task is merged, write a document to `AI_DOCS/` describing:
+AI_DOCS are for durable context that the code and commit history cannot carry on their own. Default: **do not** write one. Only write an AI_DOC when the task falls into one of these categories:
+
+- A new significant feature or a full PLAN stage.
+- An architectural change (process topology, IPC, event framing, service lifecycle, renderer contract, etc.).
+- A non-trivial refactor that changes module boundaries, public interfaces, or coding patterns across multiple files.
+
+Do **not** write an AI_DOC for:
+
+- Bug fixes. Instead, if the fix directly contradicts or extends what an existing AI_DOC or `ARCHITECTURE.md` section already says, update that document in place. Otherwise the commit message is the only record.
+- Test-only work (adding tests, fixing flakes, test refactors, moving tests under `t/AI/`). Commit messages only.
+- Trivial cleanups (typos, whitespace, perltidy passes, comment tweaks).
+
+When an AI_DOC is warranted, it should describe:
 
 - What the task was and what triggered it.
-- Decisions made during the task, including design alternatives considered and why they were rejected.
-- Any architectural changes introduced by the task.
+- Decisions made, including alternatives considered and why they were rejected.
+- Any architectural changes introduced.
 
 Filename convention: `AI_DOCS/<YYYY-MM-DD>-<short-slug>.md`.
 
-Any decision to deviate from `ARCHITECTURE.md` must also be recorded as an addendum section appended to `ARCHITECTURE.md` itself. The addendum must explain the deviation and justify it. `ARCHITECTURE.md` remains the authoritative spec; addenda exist so the spec stays self-contained and anyone reading it sees the deviation and its reasoning in one place.
+Any decision to deviate from `ARCHITECTURE.md` must **also** be recorded as an addendum section appended to `ARCHITECTURE.md` itself, explaining and justifying the deviation. `ARCHITECTURE.md` remains the authoritative spec; addenda exist so anyone reading it sees the deviation and its reasoning in one place. This rule applies regardless of whether an AI_DOC is also written.
 
 ## Testing
 


### PR DESCRIPTION
Rewrite the "AI task documentation" section to skip AI_DOCS by default
and reserve them for new significant features, architectural changes, or
non-trivial refactors. Explicitly exclude bug fixes, test-only work, and
trivial cleanups from generating AI_DOCS; bug fixes may amend an existing
AI_DOC or ARCHITECTURE.md section only when directly relevant.

The previous policy ("whenever an AI-assisted task is merged, write a
document") produced a steady stream of small per-stage and test-only
entries that duplicated what the commit history already carried. The
ARCHITECTURE.md deviation-addendum rule is preserved and now explicitly
stated to apply regardless of whether an AI_DOC is also written.
