### PR TITLE
Restore wall/CPU timing in Summary via the Collector → Streamer pipeline

### DIFF
--- a/lib/App/Yath2/Renderer/Summary.pm
+++ b/lib/App/Yath2/Renderer/Summary.pm
@@ -93,6 +93,10 @@ sub render_summary {
     my $pass_count = $run_end->{pass_count} // 0;
     my $fail_count = $run_end->{fail_count} // 0;
     my $total      = $pass_count + $fail_count;
+    my $wall_time  = $run_end->{wall_time};
+    my $cpu_times  = $run_end->{cpu_times};
+    my $cpu_total  = $run_end->{cpu_total};
+    my $cpu_usage  = $run_end->{cpu_usage};
 
     if (my $rows = $self->{+_FAILED_JOBS}) {
         if (@$rows) {
@@ -108,6 +112,21 @@ sub render_summary {
     my @summary = (
         $fail_count ? ("     Fail Count: $fail_count") : (),
         "     File Count: $total",
+        (defined $wall_time)
+        ? (
+            sprintf("      Wall Time: %.2f seconds", $wall_time),
+            ($cpu_times
+                ? (
+                    sprintf(
+                        "       CPU Time: %.2f seconds (usr: %.2fs | sys: %.2fs | cusr: %.2fs | csys: %.2fs)",
+                        $cpu_total, @{$cpu_times}[0 .. 3]
+                    ),
+                    sprintf("      CPU Usage: %i%%", $cpu_usage),
+                )
+                : ()
+            ),
+          )
+        : (),
     );
 
     my $res = "    -->  Result: " . (defined($pass) ? $pass ? 'PASSED' : 'FAILED' : 'N/A') . "  <--";
@@ -143,6 +162,11 @@ sub write_summary_file {
         total_tests    => $pass_count + $fail_count,
 
         failed => $self->{+_FAILED_JOBS},
+
+        (defined $run_end->{wall_time} ? (wall_time => $run_end->{wall_time}) : ()),
+        (defined $run_end->{cpu_total} ? (cpu_total => $run_end->{cpu_total}) : ()),
+        (defined $run_end->{cpu_usage} ? (cpu_usage => $run_end->{cpu_usage}) : ()),
+        (defined $run_end->{cpu_times} ? (cpu_times => $run_end->{cpu_times}) : ()),
     );
 
     require Test2::Harness2::Util::File::JSON;

--- a/lib/App/Yath2/Streamer/Base.pm
+++ b/lib/App/Yath2/Streamer/Base.pm
@@ -213,6 +213,7 @@ sub _apply_run_state {
                         stamp    => $now->{completed_at},
                         (defined $now->{exit}  ? (exit  => $now->{exit})  : ()),
                         (defined $now->{codes} ? (codes => $now->{codes}) : ()),
+                        (defined $now->{times} ? (times => $now->{times}) : ()),
                     },
                     harness_job_exit => {
                         job_id => $jid,
@@ -309,10 +310,34 @@ sub _harness_run_end_facet {
     my $results  = ref($state->{results}) eq 'HASH' ? $state->{results} : {};
     my $all_pass = 1;
     my ($fail_count, $pass_count) = (0, 0);
+    my @cpu_agg    = (0, 0, 0, 0);
+    my $have_times = 0;
+
     for my $jid (keys %$results) {
         next unless defined $results->{$jid}{completed_at};
         if ($results->{$jid}{pass}) { $pass_count++ }
         else                        { $fail_count++; $all_pass = 0 }
+        if (my $t = $results->{$jid}{times}) {
+            $cpu_agg[$_] += $t->[$_] for 0 .. 3;
+            $have_times = 1;
+        }
+    }
+
+    my $stamp     = _max_completed_at($results) // time;
+    my $wall_time = defined $state->{created_at} ? ($stamp - $state->{created_at}) : undef;
+
+    my %timing;
+    if ($have_times) {
+        my $cpu_total = $cpu_agg[0] + $cpu_agg[1] + $cpu_agg[2] + $cpu_agg[3];
+        %timing = (
+            wall_time => $wall_time,
+            cpu_times => \@cpu_agg,
+            cpu_total => $cpu_total,
+            cpu_usage => ($wall_time && $wall_time > 0) ? int($cpu_total / $wall_time * 100) : 0,
+        );
+    }
+    elsif (defined $wall_time) {
+        %timing = (wall_time => $wall_time);
     }
 
     return {
@@ -320,7 +345,8 @@ sub _harness_run_end_facet {
         pass       => $all_pass ? 1 : 0,
         pass_count => $pass_count,
         fail_count => $fail_count,
-        stamp      => _max_completed_at($results) // time,
+        stamp      => $stamp,
+        %timing,
     };
 }
 

--- a/lib/Test2/Harness2/Collector.pm
+++ b/lib/Test2/Harness2/Collector.pm
@@ -66,6 +66,7 @@ use Object::HashBase qw{
     <child_exit
 
     +_win32_job
+    +_start_times
 };
 
 # Default auditor accessors for the base class. Test2::Harness2::Collector::Test
@@ -115,6 +116,8 @@ sub init {
 
     $self->{+JOB_ID}  //= gen_uuid();
     $self->{+JOB_TRY} //= 0;
+
+    $self->{+_START_TIMES} = [times()];
 
     $self->{+KILL_TIMEOUT} //= 15;
     $self->{+ENV_VARS}     //= {};
@@ -1052,11 +1055,18 @@ sub _finalize_collection {
     if (defined $child_exit) {
         $self->{+CHILD_EXIT} = $child_exit;
 
+        my $end_times   = [times()];
+        my $start_times = $self->{+_START_TIMES};
+        my @cpu_times   = map { $end_times->[$_] - $start_times->[$_] } 0 .. 3;
+
+        my $px = parse_exit($child_exit);
+        $px->{times} = \@cpu_times;
+
         my $exit_event = Test2::Harness2::Event->new(
             event_id   => gen_uuid(),
             stamp      => time,
             facet_data => {
-                harness_process_exit => parse_exit($child_exit),
+                harness_process_exit => $px,
             },
         );
         $self->_process_event($exit_event);

--- a/lib/Test2/Harness2/Collector/Auditor/Test.pm
+++ b/lib/Test2/Harness2/Collector/Auditor/Test.pm
@@ -403,6 +403,7 @@ sub _subtest_process {
             exit    => $px->{all},
             codes   => $px,
             stamp   => $event->{stamp} // $f->{harness}->{stamp} // time,
+            (defined $px->{times} ? (times => $px->{times}) : ()),
         };
 
         push @{$f->{errors}} => $self->fail_error_facet_list;

--- a/lib/Test2/Harness2/Collector/Observer/TestObserver.pm
+++ b/lib/Test2/Harness2/Collector/Observer/TestObserver.pm
@@ -228,6 +228,8 @@ sub _emit_completed {
         $payload{fail_count} = $auditor->fail_count   if $auditor->can('fail_count');
     }
 
+    $payload{times} = $exit_facet->{times} if $exit_facet->{times};
+
     $self->_send_to_run(\%payload);
 
     $self->_send_to_harness({

--- a/lib/Test2/Harness2/RunService.pm
+++ b/lib/Test2/Harness2/RunService.pm
@@ -542,6 +542,7 @@ sub _handle_test_job_completed {
     $r->{codes}        = $content->{codes};
     $r->{pass_count}   = $content->{pass_count};
     $r->{fail_count}   = $content->{fail_count};
+    $r->{times}        = $content->{times} if $content->{times};
     $r->{stamp}        = $completed_at;
     $r->{completed_at} = $completed_at;
 

--- a/t/AI/unit/App/Yath2/Renderer/Summary.t
+++ b/t/AI/unit/App/Yath2/Renderer/Summary.t
@@ -63,6 +63,28 @@ subtest 'render_summary prints pass result' => sub {
     like($buf, qr/File Count: 3/, 'file count shown');
 };
 
+subtest 'render_summary shows timing when present' => sub {
+    my $r   = make_renderer();
+    my $buf = '';
+    local *STDOUT;
+    open(STDOUT, '>', \$buf) or die "Cannot redirect STDOUT: $!";
+    $r->render_summary({
+        pass       => 1,
+        pass_count => 2,
+        fail_count => 0,
+        wall_time  => 10.5,
+        cpu_times  => [2.1, 0.3, 5.0, 0.1],
+        cpu_total  => 7.5,
+        cpu_usage  => 71,
+    });
+    close STDOUT;
+    open(STDOUT, '>&', \*STDERR);
+    like($buf, qr/Wall Time.*10\.50 seconds/, 'wall time shown');
+    like($buf, qr/CPU Time/, 'cpu time shown');
+    like($buf, qr/CPU Usage.*71%/, 'cpu usage shown');
+    like($buf, qr/usr:.*2\.10/, 'user time shown');
+};
+
 subtest 'render_summary prints fail result' => sub {
     my $r   = make_renderer();
     my $buf = '';


### PR DESCRIPTION
Collector now captures [times()] at job start and diffs at process exit, emitting the four-element [usr, sys, cusr, csys] array in harness_process_exit. The chain carries it forward:
  - Auditor::Test forwards times into harness_job_exit
  - TestObserver includes it in the test_job_completed IPC message
  - RunService stores it in per-job results (results.$jid.times)
  - Streamer aggregates it across all completed jobs in _harness_run_end_facet, also computing wall_time (created_at → max completed_at) and cpu_usage %
  - Summary.pm renders wall/cpu lines when the fields are present, and writes them into the summary JSON file

Timing fields are optional throughout: runs without a full collector stack (e.g. replaying a log) will show wall_time only if created_at is in state, and skip the CPU lines entirely if no per-job times were reported.