### PR TITLE
t/Yath/integration: untrack the deliberately-broken symlink

### DIFF
--- a/t/Yath/integration/test-broken-symlinks/broken-symlink.tx
+++ b/t/Yath/integration/test-broken-symlinks/broken-symlink.tx
@@ -1,1 +1,0 @@
-nothing-there


### PR DESCRIPTION
Dist::Zilla's [Git::GatherDir / GatherDotFilesT] walks t/ during
build and stat()s every file, so the dangling symlink at
t/Yath/integration/test-broken-symlinks/broken-symlink.tx
(-> nothing-there) makes `dzil test` fail with
"does not exist!" before any test can run.

Drop it from the index. .gitignore already covers the path
(t/Yath/integration/test-broken-symlinks/broken-symlink.tx, line
60). The file stays on disk for the local checkout; when
t/Yath/integration/test.t is unskipped, its body recreates the
dangling symlink at runtime via
`unlink $sym; symlink('nothing-there', $sym)` -- the same pattern
the legacy t/integration/test.t uses on this repo's existing
gitignore entry on line 59.

This was lost during a rebase of the prior squash; restoring it
so dzil test passes again.

Co-Authored-By: Claude <noreply@anthropic.com>
