### PR TITLE
nested includes

### DIFF
--- a/lib/App/Yath2/Command/test.pm
+++ b/lib/App/Yath2/Command/test.pm
@@ -79,10 +79,12 @@ sub run {
     # Build the extension filter from --ext / --extensions / --extension
     # (App::Yath2::Options::Finder), defaulting to t and t2. Used only
     # when an arg is a directory; explicit file paths are always
-    # accepted regardless of extension.
-    my @ext = $settings->check_group('finder')
-        ? @{ $settings->finder->extensions // [qw/t t2/] }
-        : qw/t t2/;
+    # accepted regardless of extension. Be defensive: unit tests pass
+    # in mock settings objects that may not implement check_group.
+    my @ext = qw/t t2/;
+    if (eval { $settings->can('check_group') && $settings->check_group('finder') }) {
+        @ext = @{ $settings->finder->extensions // [qw/t t2/] };
+    }
     my $ext_re = join '|', map { quotemeta } @ext;
 
     my @files;

--- a/lib/App/Yath2/Command/test.pm
+++ b/lib/App/Yath2/Command/test.pm
@@ -73,14 +73,41 @@ sub run {
     my $settings = $self->{+SETTINGS};
     my $args     = $self->{+ARGS} // [];
 
-    die "No test files supplied.\nUsage: yath test FILE [FILE ...]\n"
+    die "No test files supplied.\nUsage: yath test FILE-OR-DIR [...]\n"
         unless @$args;
 
+    # Build the extension filter from --ext / --extensions / --extension
+    # (App::Yath2::Options::Finder), defaulting to t and t2. Used only
+    # when an arg is a directory; explicit file paths are always
+    # accepted regardless of extension.
+    my @ext = $settings->check_group('finder')
+        ? @{ $settings->finder->extensions // [qw/t t2/] }
+        : qw/t t2/;
+    my $ext_re = join '|', map { quotemeta } @ext;
+
     my @files;
-    for my $file (@$args) {
-        die "Not a readable test file: $file\n" unless -f $file && -r _;
-        push @files => Test2::Harness2::TestFile->new(file => $file);
+    for my $arg (@$args) {
+        if (-d $arg) {
+            require File::Find;
+            File::Find::find(
+                {
+                    no_chdir => 1,
+                    wanted   => sub {
+                        return unless -f $_ && -r _;
+                        return unless /\.(?:$ext_re)\z/;
+                        no strict 'refs';
+                        push @files => Test2::Harness2::TestFile->new(file => ${'File::Find::name'});
+                    },
+                },
+                $arg,
+            );
+            next;
+        }
+        die "Not a readable test file or directory: $arg\n" unless -f $arg && -r _;
+        push @files => Test2::Harness2::TestFile->new(file => $arg);
     }
+
+    die "No test files matched extensions (@ext) under: @$args\n" unless @files;
 
     my $workdir = $settings->workspace->workdir;
 

--- a/lib/App/Yath2/Tester.pm
+++ b/lib/App/Yath2/Tester.pm
@@ -127,7 +127,16 @@ sub yath {
     # inject_includes() will splat @INC from this list before the V2
     # require, so a stale CPAN install can't outrace our in-tree
     # lib/App/Yath/Script/V2.pm via Perl's default search path.
-    $ENV{T2_HARNESS_INCLUDES} = join ';' => $apppath, grep { $_ ne '.' } @INC;
+    # Append rather than clobber so a caller-set T2_HARNESS_INCLUDES
+    # (used e.g. by t/Yath/integration/nested_includes.t to inject
+    # paths into the spawned test child's @INC) survives.
+    {
+        my $tester_inc = join ';' => $apppath, grep { $_ ne '.' } @INC;
+        my $caller_inc = $ENV{T2_HARNESS_INCLUDES};
+        $ENV{T2_HARNESS_INCLUDES} = (defined $caller_inc && length $caller_inc)
+            ? "$caller_inc;$tester_inc"
+            : $tester_inc;
+    }
     $ENV{$_} = $env->{$_} for keys %$env;
     $ENV{YATH_COLOR} = 0;
     my $pid = start_process \@cmd => sub {

--- a/lib/Test2/Harness2.pm
+++ b/lib/Test2/Harness2.pm
@@ -1765,6 +1765,12 @@ sub _launch_job {
 
     my $assign_id = gen_uuid();
     my %env;
+    # Forward T2_HARNESS_INCLUDES from the parent environment to the
+    # spawned test child so callers can inject paths into the child's
+    # @INC without resorting to per-test CLI flags. Mirrors
+    # reference/old2/lib/Test2/Harness2/TestSettings.pm:122.
+    $env{T2_HARNESS_INCLUDES} = $ENV{T2_HARNESS_INCLUDES}
+        if defined $ENV{T2_HARNESS_INCLUDES} && length $ENV{T2_HARNESS_INCLUDES};
     my %assign_args = %{$opts{assign_args} // {}};
     for my $res (@$resources) {
         $res->assign(id => $assign_id, job => $job, env => \%env, %assign_args);

--- a/lib/Test2/Harness2/RunService.pm
+++ b/lib/Test2/Harness2/RunService.pm
@@ -191,8 +191,20 @@ sub request_handler_launch_job {
 
     # The harness's synthetic-skip / synthetic-fail paths hand us an
     # explicit launch command (perl -e '...'). Default to running the
-    # real test file when no override is present.
-    $launch_cmd //= [$^X, '-Ilib', $test_file_abs];
+    # real test file when no override is present. When the launch
+    # payload's env carries T2_HARNESS_INCLUDES (forwarded by
+    # Test2::Harness2::_launch_job), turn it into -I flags so the
+    # child's @INC actually picks the paths up -- the env var alone
+    # is not enough since exec(perl ...) starts a fresh interpreter.
+    if (!defined $launch_cmd) {
+        my @extra_inc;
+        if (my $payload_env = $payload->{env}) {
+            my $inc = $payload_env->{T2_HARNESS_INCLUDES};
+            @extra_inc = grep { length && $_ ne '.' } split /;/, $inc
+                if defined $inc && length $inc;
+        }
+        $launch_cmd = [$^X, (map { "-I$_" } @extra_inc), '-Ilib', $test_file_abs];
+    }
 
     # Default the payload-level log_file only if the caller wants one;
     # loggers are otherwise driven entirely by the payload_loggers

--- a/t/Yath/integration/nested_includes.t
+++ b/t/Yath/integration/nested_includes.t
@@ -1,9 +1,5 @@
 # HARNESS-CONFLICTS YATH
 use Test2::V0;
-plan skip_all => "TODO: nested includes / HARNESS-* parsing not aligned with current finder";
-__END__
-
-use Test2::V0;
 
 use File::Temp qw/tempdir/;
 use File::Spec;


### PR DESCRIPTION
- **dist.ini: exclude broken-symlink fixture from dzil gather**
- **App::Yath2::Command::init: port from reference/old2**
- **Command::test: accept directory args, honour --ext for filtering**
- **nested_includes.t: propagate T2_HARNESS_INCLUDES to test child**
