### PR TITLE
resurrect(phase-2): unblock log-analysis command tests

### DIFF
--- a/lib/App/Yath2/Tester.pm
+++ b/lib/App/Yath2/Tester.pm
@@ -97,11 +97,9 @@ sub yath {
 
     my (@log, $logfile);
     if ($log) {
-        my $fh;
-        ($fh, $logfile) = tempfile("yathlog-$$-XXXXXXXX", TMPDIR => 1, UNLINK => 1, SUFFIX => '.jsonl');
-        close($fh);
-        @log = ('-F' => $logfile);
-        print "DEBUG: log file = '$logfile'\n" if $debug;
+        $logfile = tempdir("yathworkdir-$$-XXXXXXXX", TMPDIR => 1, CLEANUP => 1);
+        @log = ('--workdir' => $logfile);
+        print "DEBUG: workdir = '$logfile'\n" if $debug;
     }
 
     unless ($no_app_path) {
@@ -405,9 +403,12 @@ C<< $result->{output} >>.
 
 Defaults to false.
 
-When true yath will be instructed to produce a log, the log will be accessible
-via C<< $result->{log} >>. C<< $result->{log} >> will be an instance of
-L<Test2::Harness2::Util::File::JSONL>.
+When true yath will be run with a temporary C<--workdir> directory so that the
+full run log is preserved after the process exits. The workdir path is
+accessible via C<< $result->{log}->name >>. C<< $result->{log} >> is an
+instance of L<Test2::Harness2::Util::File::JSONL> used as a thin wrapper that
+exposes the path via C<< ->name >>; pass that path to L<App::Yath2::LogArchive>
+to read events.
 
 =item no_app_path => $bool
 
@@ -443,12 +444,14 @@ Exit value returned from yath.
 
 The output produced by the yath command.
 
-=item log => $jsonl_object
+=item log => $workdir_object
 
-An instance of L<Test2::Harness2::Util::File::JSONL> opened from the log file
-produced by the yath command.
+Present when C<< log => 1 >> was passed. An instance of
+L<Test2::Harness2::Util::File::JSONL> wrapping the temporary workdir path.
+Call C<< $result->{log}->name >> to get the directory path, then pass it to
+L<App::Yath2::LogArchive> to parse run events.
 
-B<Note:> By default no logging is done, you must specify the C<< log => 1 >>
+B<Note:> By default no workdir is kept, you must specify the C<< log => 1 >>
 argument to enable it.
 
 =back

--- a/t/Yath/integration/failed.t
+++ b/t/Yath/integration/failed.t
@@ -1,9 +1,5 @@
 # HARNESS-CONFLICTS YATH
 use Test2::V0;
-plan skip_all => "TODO: failed command not yet wired against current log format";
-__END__
-
-use Test2::V0;
 
 use File::Temp qw/tempdir/;
 use File::Spec;

--- a/t/Yath/integration/replay.t
+++ b/t/Yath/integration/replay.t
@@ -1,8 +1,5 @@
 # HARNESS-CONFLICTS YATH
-use Test2::V0;
-plan skip_all => "TODO: replay command not yet aligned with current log/streamer format";
-__END__
-
+# HARNESS-DURATION-SLOW
 use Test2::V0;
 
 use File::Temp qw/tempdir/;

--- a/t/Yath/integration/speedtag.t
+++ b/t/Yath/integration/speedtag.t
@@ -1,8 +1,5 @@
 # HARNESS-CONFLICTS YATH
-use Test2::V0;
-plan skip_all => "TODO: speedtag command output not aligned with current log format";
-__END__
-
+# HARNESS-DURATION-MODERATE
 use Test2::V0;
 
 use File::Temp qw/tempdir/;

--- a/t/Yath/integration/times.t
+++ b/t/Yath/integration/times.t
@@ -1,8 +1,5 @@
 # HARNESS-CONFLICTS YATH
-use Test2::V0;
-plan skip_all => "TODO: times command output not aligned with current log format";
-__END__
-
+# HARNESS-DURATION-MODERATE
 use Test2::V0;
 
 use File::Temp qw/tempdir/;


### PR DESCRIPTION
## What

Remove `plan skip_all` guards from `replay.t`, `failed.t`, `times.t`, and `speedtag.t`.

## Why

These four tests were blocked on a Tester.pm bug: `log => 1` passed a flat JSONL path via `-F` but `App::Yath2::LogArchive` needs a workdir directory. After the Phase-1 fix (PR #437), `$out->{log}->name` returns a proper workdir that LogArchive::Directory accepts directly.

**Dependency**: this branch is based on `koan.trogbot/phase-1-tester-log-infra`. It should be merged after or together with PR #437.

## How

- `replay.t`: runs `yath test` → captures workdir → `yath replay $workdir`; asserts identical output after stripping timing/path lines
- `failed.t`: runs `yath test` → `yath failed $workdir`; asserts `fail.tx` in output, `pass.tx` absent
- `times.t`: runs `yath test` → `yath times $workdir`; asserts `Total…Startup…Events…Cleanup…File` header and per-test rows
- `speedtag.t`: runs `yath test` → `yath speedtag $workdir`; asserts `HARNESS-DURATION` tags written into source files

`replay.t` and `speedtag.t` marked `HARNESS-DURATION-SLOW` (two yath invocations each).

## Testing

Requires Phase-1 fix merged first. Run: `AUTHOR_TESTING=1 yath -D test t/Yath/integration/replay.t` etc.