### PR TITLE
Collector: sleep with exponential backoff when idle instead of busy-looping

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@
 
     - Add [PruneCruft] to dist.ini so build artifacts (blib/,
       pm_to_blib, MYMETA.*) no longer leak into release tarballs.
+    - Fix collector busy-loop: sleep with exponential backoff (1ms..100ms)
+      when no events were processed, instead of never sleeping while any
+      job is active. Collector CPU usage drops from 100% of a core to ~0
+      during normal runs.
 
 1.000172  2026-04-28 21:15:51-07:00 America/Los_Angeles
 

--- a/lib/Test2/Harness/Collector.pm
+++ b/lib/Test2/Harness/Collector.pm
@@ -10,7 +10,7 @@ use Test2::Harness::Collector::JobDir;
 
 use Test2::Harness::Util::UUID qw/gen_uuid/;
 use Test2::Harness::Util::Queue;
-use Time::HiRes qw/sleep time/;
+use Time::HiRes qw/sleep time usleep/;
 use File::Spec;
 
 use File::Path qw/remove_tree/;
@@ -57,10 +57,14 @@ sub process {
     my %warning_seen;
     my $settings = $self->settings;
 
+    my $idle_wait = 1_000;    # µs
+
     while (1) {
         my $count = 0;
-        $count += $self->process_runner_output if $self->{+SHOW_RUNNER_OUTPUT};
-        $count += $self->process_tasks();
+        my $work  = 0;
+        $work += $self->process_runner_output if $self->{+SHOW_RUNNER_OUTPUT};
+        $work += $self->process_tasks();
+        $count += $work;
 
         my $jobs = $self->jobs;
 
@@ -84,6 +88,7 @@ sub process {
             }
 
             $count += $e_count;
+            $work  += $e_count;
             next if $e_count;
             my $done = $jdir->done;
             unless ($done) {
@@ -119,7 +124,14 @@ sub process {
         }
 
         last if !$count && $self->runner_exited;
-        sleep $self->{+WAIT_TIME} unless $count;
+
+        if ($work) {
+            $idle_wait = 1_000;
+        }
+        else {
+            usleep($idle_wait);
+            $idle_wait = $idle_wait * 2 > 100_000 ? 100_000 : $idle_wait * 2;
+        }
     }
 
     # One last slurp


### PR DESCRIPTION
The main collector loop only slept when $count was 0, but $count is incremented unconditionally for every active job (once for existing, once more for not being done yet). As a result the loop never slept while at least one test was running, polling job dir files as fast as possible and pinning a full CPU core for the duration of the run, regardless of concurrency settings.

Track actually-processed work (runner output lines, queue tasks, job events) separately from the liveness counter that guards loop exit. When an iteration processes nothing, usleep with exponential backoff starting at 1ms and doubling up to a 100ms cap; any activity resets the backoff to 1ms.

Note: the collector's wait_time attribute (default 0.02s, not exposed as a CLI option and never set from within the dist) is no longer read by this loop.

P.S.: claude used.