### PR TITLE
shared locks: like LOCK_SH for HARNESS-CONFLICTS's LOCK_EX

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+    - Add the # HARNESS-SHARES-XXX directive, a shared claim on a name: any number of tests sharing XXX run at the same time, but none run alongside a # HARNESS-CONFLICTS-XXX test, which claims XXX exclusively.
+
 1.000174  2026-08-17 13:00:43-07:00 America/Los_Angeles
 
     - Teach find_yath() to check $ENV{YATH_SCRIPT}, the directories paired with @INC entries, and PATH, so an uninstalled yath script (as CPAN smokers use) is found instead of aborting the test run.

--- a/lib/App/Yath.pm
+++ b/lib/App/Yath.pm
@@ -733,6 +733,26 @@ XXX can be replaced with any type of your choosing.
 NOTE: This directive does not alter the category of your test. You are free
 to mark the test with LONG or MEDIUM in addition to this marker.
 
+=over 4
+
+=item Example with multiple lines.
+
+    #!/usr/bin/perl
+    # DASH and space are split the same way.
+    # HARNESS-CONFLICTS-DAEMON
+    # HARNESS-CONFLICTS  MYSQL
+
+    ...
+
+=item Or on a single line.
+
+    #!/usr/bin/perl
+    # HARNESS-CONFLICTS DAEMON MYSQL
+
+    ...
+
+=back
+
 =head3 HARNESS-SHARES-XXX
 
 This lets you tell C<yath> that this test uses XXX, but is happy to share it
@@ -768,26 +788,6 @@ Specify a range of job slots needed for the test to run. If set to a single
 value then the test will only run if it can have the specified number of slots.
 If given a range the test will require at least the lower number of slots, and
 use up to the maximum number of slots.
-
-=over 4
-
-=item Example with multiple lines.
-
-    #!/usr/bin/perl
-    # DASH and space are split the same way.
-    # HARNESS-CONFLICTS-DAEMON
-    # HARNESS-CONFLICTS  MYSQL
-
-    ...
-
-=item Or on a single line.
-
-    #!/usr/bin/perl
-    # HARNESS-CONFLICTS DAEMON MYSQL
-
-    ...
-
-=back
 
 =head3 HARNESS-RETRY-n
 

--- a/lib/App/Yath.pm
+++ b/lib/App/Yath.pm
@@ -733,6 +733,33 @@ XXX can be replaced with any type of your choosing.
 NOTE: This directive does not alter the category of your test. You are free
 to mark the test with LONG or MEDIUM in addition to this marker.
 
+=head3 HARNESS-SHARES-XXX
+
+This lets you tell C<yath> that this test uses XXX, but is happy to share it
+with other tests that merely use it too. Any number of C<HARNESS-SHARES-XXX>
+tests may run at the same time, but none of them will run at the same time
+as a C<HARNESS-CONFLICTS-XXX> test. If you think of the two directives as a
+lock on the name XXX, C<CONFLICTS> takes it exclusively and C<SHARES> takes
+it shared.
+
+XXX can be replaced with any type of your choosing, and you may set several
+of them.
+
+The usual shape for this is one test that disturbs a resource and many that
+merely read it: mark the disruptive one C<HARNESS-CONFLICTS-XXX> and the
+rest C<HARNESS-SHARES-XXX>, and the readers keep their parallelism instead
+of being serialized alongside the writer.
+
+NOTE: An exclusive test has to wait for every shared test holding the name
+to finish, and C<yath> will not hold job slots empty to make room for it. If
+shared tests keep becoming available the exclusive one may run quite late in
+the run, possibly last and by itself. This is still better than marking
+every test C<CONFLICTS>, but it is worth knowing before you mark hundreds of
+tests as sharing one name.
+
+NOTE: This directive does not alter the category of your test. You are free
+to mark the test with LONG or MEDIUM in addition to this marker.
+
 =head3 HARNESS-JOB-SLOTS 2
 
 =head3 HARNESS-JOB-SLOTS 1 10

--- a/lib/App/Yath/Command/status.pm
+++ b/lib/App/Yath/Command/status.pm
@@ -73,10 +73,10 @@ sub run {
             next;
         }
 
-        my @rows = map {[$_->{job_id}, $_->{is_try} // $_->{job_try} // 0, $_->{rel_file}, join(', ' => @{$_->{conflicts} // []})]} @tasks;
+        my @rows = map {[$_->{job_id}, $_->{is_try} // $_->{job_try} // 0, $_->{rel_file}, join(', ' => @{$_->{conflicts} // []}), join(', ' => @{$_->{shares} // []})]} @tasks;
         my $run_table = Term::Table->new(
             collapse => 1,
-            header => [qw/uuid try test conflicts/],
+            header => [qw/uuid try test conflicts shares/],
             rows => [ sort { $a->[2] cmp $b->[2] } @rows ],
         );
 
@@ -128,11 +128,11 @@ sub run {
     print "\n**** Running tests: ****\n";
     my $running = $state->running_tasks;
     my $running_tasks = [values %$running];
-    my @rows = map {[$self->get_job_pid($_->{run_id}, $_->{job_id}) // 'N/A', $_->{job_id}, $_->{is_try} // $_->{job_try} // 0, $_->{rel_file}, join(', ' => @{$_->{conflicts} // []})]} @$running_tasks;
+    my @rows = map {[$self->get_job_pid($_->{run_id}, $_->{job_id}) // 'N/A', $_->{job_id}, $_->{is_try} // $_->{job_try} // 0, $_->{rel_file}, join(', ' => @{$_->{conflicts} // []}), join(', ' => @{$_->{shares} // []})]} @$running_tasks;
     if (@rows) {
         my $run_table = Term::Table->new(
             collapse => 1,
-            header => [qw/pid uuid try test conflicts/],
+            header => [qw/pid uuid try test conflicts shares/],
             rows => [ sort { $a->[0] <=> $b->[0] } @rows ],
         );
         print "$_\n" for $run_table->render;

--- a/lib/Test2/Harness/Runner/State.pm
+++ b/lib/Test2/Harness/Runner/State.pm
@@ -44,6 +44,7 @@ use Test2::Harness::Util::HashBase(
         <running_categories
         <running_durations
         <running_conflicts
+        <running_shares
         <running_tasks
 
         <stage_readiness
@@ -428,10 +429,21 @@ sub _start_task {
     $self->{+RUNNING_CATEGORIES}->{$cat}++;
     $self->{+RUNNING_DURATIONS}->{$dur}++;
 
-    my $cfls = $task->{conflicts} //= [];
+    my ($cfls, $shrs) = $self->task_locks($task);
+
     for my $cfl (@$cfls) {
+        die "Unexpected shared use of '$cfl' ($self->{+RUNNING_SHARES}->{$cfl}) running at this time!"
+            if $self->{+RUNNING_SHARES}->{$cfl};
+
         die "Unexpected parallel conflict '$cfl' ($self->{+RUNNING_CONFLICTS}->{$cfl}) running at this time!"
             if $self->{+RUNNING_CONFLICTS}->{$cfl}++;
+    }
+
+    for my $shr (@$shrs) {
+        die "Unexpected exclusive conflict '$shr' running at this time!"
+            if $self->{+RUNNING_CONFLICTS}->{$shr};
+
+        $self->{+RUNNING_SHARES}->{$shr}++;
     }
 
     return;
@@ -459,8 +471,9 @@ sub _stop_task {
     $self->{+RUNNING_CATEGORIES}->{$cat}--;
     $self->{+RUNNING_DURATIONS}->{$dur}--;
 
-    my $cfls = $task->{conflicts} //= [];
+    my ($cfls, $shrs) = $self->task_locks($task);
     $self->{+RUNNING_CONFLICTS}->{$_}-- for @$cfls;
+    $self->{+RUNNING_SHARES}->{$_}--    for @$shrs;
 
     return;
 }
@@ -575,6 +588,22 @@ sub task_stage {
     return $self->preloader->task_stage($task->{file}, $wants);
 }
 
+sub task_locks {
+    my $self = shift;
+    my ($task) = @_;
+
+    my $conflicts = $task->{conflicts} //= [];
+    my $shares    = $task->{shares}    //= [];
+
+    # An exclusive claim on a name gazumps a shared one, so a task holding both
+    # must not be counted as waiting on itself.  The scanner already drops
+    # these, but tasks can also be queued by hand, where the scanner will not
+    # have been able to fix it up.
+    my %exclusive = map { ($_ => 1) } @$conflicts;
+
+    return ($conflicts, [grep { !$exclusive{$_} } @$shares]);
+}
+
 sub task_pending_lookup {
     my $self = shift;
     my ($task) = @_;
@@ -599,6 +628,11 @@ sub task_fields {
     die "Invalid duration: $dur" unless DURATIONS->{$dur};
 
     $cat = 'conflicts' if $cat eq 'general' && $task->{conflicts} && @{$task->{conflicts}};
+
+    # Note that "shares" deliberately does NOT promote a task into the
+    # "conflicts" bucket. That bucket is searched ahead of "general", which is
+    # what lets an exclusive task claim a name before a shared one takes it,
+    # which would makes the exclusive task wait.
 
     return ($run_id, $smoke, $stage, $cat, $dur);
 }
@@ -761,6 +795,7 @@ sub _next {
     my $pending = $self->{+PENDING_TASKS}->{$run_id} or return;
 
     my $conflicts = $self->{+RUNNING_CONFLICTS};
+    my $shares    = $self->{+RUNNING_SHARES};
     my $cat_order = $self->_cat_order;
     my $dur_order = $self->_dur_order;
     my $stages    = $self->_stage_order();
@@ -782,14 +817,23 @@ sub _next {
                 for my $ldur (@$dur_order) {
                     my $search = $search->{$ldur} or next;
 
-                    # Make sure anything with conflicts runs early.
+                    # Make sure anything with conflicts runs early, then
+                    # anything with shares, which an exclusive task may be
+                    # waiting on.
                     unless ($SORTED{$search}++) {
-                        @$search = sort { scalar(@{$b->{conflicts}}) <=> scalar(@{$a->{conflicts}}) } @$search;
+                        @$search = sort {
+                            scalar(@{$b->{conflicts} // []}) <=> scalar(@{$a->{conflicts} // []})
+                                || scalar(@{$b->{shares} // []}) <=> scalar(@{$a->{shares} // []})
+                        } @$search;
                     }
 
                     for my $task (@$search) {
-                        # If the job has a listed conflict and an existing job is running with that conflict, then pick another job.
-                        next if first { $conflicts->{$_} } @{$task->{conflicts}};
+                        # An exclusive claim on a name cannot be made while any
+                        # other job holds that name, exclusively or shared.
+                        next if first { $conflicts->{$_} || $shares->{$_} } @{$task->{conflicts} // []};
+
+                        # A shared claim only has to wait out an exclusive holder.
+                        next if first { $conflicts->{$_} } @{$task->{shares} // []};
 
                         my $ok = 1;
                         my @resource_skip;

--- a/lib/Test2/Harness/TestFile.pm
+++ b/lib/Test2/Harness/TestFile.pm
@@ -189,6 +189,10 @@ sub conflicts_list {
     return $_[0]->headers->{conflicts} || [];    # Assure conflicts is always an array ref.
 }
 
+sub shares_list {
+    return $_[0]->headers->{shares} || [];    # Assure shares is always an array ref.
+}
+
 sub headers {
     my $self = shift;
     $self->_scan unless $self->{+_SCANNED};
@@ -343,6 +347,14 @@ sub _scan {
             # Make sure no more than 1 conflict is ever present.
             @{$headers{conflicts}} = uniq @{$headers{conflicts}};
         }
+        elsif ($dir eq 'shares') {
+            # Allow multiple lines with # HARNESS-SHARES FOO
+            $headers{shares} ||= [];
+            push @{$headers{shares}}, map { lc($_) } @args;
+
+            # Make sure no more than 1 share of a name is ever present.
+            @{$headers{shares}} = uniq @{$headers{shares}};
+        }
         elsif ($dir eq 'timeout') {
             my ($type, $num, $extra) = @args;
             $type = lc($type);
@@ -362,6 +374,19 @@ sub _scan {
         else {
             warn "Unknown harness directive '$dir' at $self->{+FILE} line $ln.\n";
         }
+    }
+
+    # An exclusive lock on a name gazumps a shared one, so if a file asks for
+    # both we keep the exclusive and drop the shared. This is probably a
+    # mistake on the author's part, so warn.
+    if ($headers{conflicts} && $headers{shares}) {
+        my %exclusive = map { ($_ => 1) } @{$headers{conflicts}};
+
+        for my $both (grep { $exclusive{$_} } @{$headers{shares}}) {
+            warn "'$both' is listed as both a conflict and a share in $self->{+FILE}, treating it as a conflict.\n";
+        }
+
+        @{$headers{shares}} = grep { !$exclusive{$_} } @{$headers{shares}};
     }
 
     $self->{+_HEADERS} = \%headers;
@@ -442,6 +467,7 @@ sub queue_item {
         binary      => $binary,
         category    => $category,
         conflicts   => $self->conflicts_list,
+        shares      => $self->shares_list,
         duration    => $duration,
         file        => $self->file,
         rel_file    => $self->relative,
@@ -607,6 +633,10 @@ C<undef> will be returned.
 =item $arrayref = $tf->conflicts_list()
 
 Get a list of conflict markers.
+
+=item $arrayref = $tf->shares_list()
+
+Get a list of shared-use markers.
 
 =item $seconds = $tf->event_timeout()
 

--- a/t/integration/shares.t
+++ b/t/integration/shares.t
@@ -1,0 +1,68 @@
+use Test2::V0;
+
+use File::Spec;
+
+use App::Yath::Tester qw/yath/;
+use Test2::Harness::Util::File::JSONL;
+
+my $dir = __FILE__;
+$dir =~ s{\.t$}{}g;
+$dir =~ s{^\./}{};
+
+# HARNESS-SHARES-DB tests may run alongside each other, but never alongside a
+# HARNESS-CONFLICTS-DB test. Read the window each test was live for out of the
+# log and check which windows were allowed to overlap.
+yath(
+    command => 'test',
+    args    => [$dir, '--ext=tx', '-j4'],
+    log     => 1,
+    exit    => 0,
+    test    => sub {
+        my $out = shift;
+        my $log = $out->{log};
+
+        my (%name, %start, %stop);
+
+        my @events = $log->poll();
+        while (@events) {
+            if (my $event = shift @events) {
+                my $f      = $event->{facet_data};
+                my $job_id = $event->{job_id} // next;
+
+                if (my $s = $f->{harness_job_start}) {
+                    $name{$job_id}  = (File::Spec->splitpath($s->{rel_file}))[-1];
+                    $start{$job_id} = $s->{stamp};
+                }
+
+                if (my $e = $f->{harness_job_exit}) {
+                    $stop{$job_id} = $e->{stamp};
+                }
+            }
+
+            # Check for additional events, probably should not have any, but we
+            # may hit a buffering limit in the log reader and need additional
+            # polls.
+            push @events => $log->poll;
+        }
+
+        my %window;
+        for my $job_id (keys %name) {
+            $window{$name{$job_id}} = [$start{$job_id}, $stop{$job_id}];
+        }
+
+        is([sort keys %window], [sort qw/exclusive.tx shared_a.tx shared_b.tx/], "Found all three tests in the log");
+
+        my $overlap = sub {
+            my ($x, $y) = @_;
+            my ($xa, $xb) = @{$window{$x}};
+            my ($ya, $yb) = @{$window{$y}};
+            return $xa < $yb && $ya < $xb;
+        };
+
+        ok(!$overlap->('exclusive.tx', 'shared_a.tx'), "exclusive did not run alongside shared_a");
+        ok(!$overlap->('exclusive.tx', 'shared_b.tx'), "exclusive did not run alongside shared_b");
+        ok($overlap->('shared_a.tx', 'shared_b.tx'),   "the two shared tests did run alongside each other");
+    },
+);
+
+done_testing;

--- a/t/integration/shares/exclusive.tx
+++ b/t/integration/shares/exclusive.tx
@@ -1,0 +1,8 @@
+use Test2::V0;
+# HARNESS-CONFLICTS-DB
+
+sleep 1;
+ok(1, "pass");
+sleep 1;
+
+done_testing;

--- a/t/integration/shares/shared_a.tx
+++ b/t/integration/shares/shared_a.tx
@@ -1,0 +1,8 @@
+use Test2::V0;
+# HARNESS-SHARES-DB
+
+sleep 1;
+ok(1, "pass");
+sleep 1;
+
+done_testing;

--- a/t/integration/shares/shared_b.tx
+++ b/t/integration/shares/shared_b.tx
@@ -1,0 +1,8 @@
+use Test2::V0;
+# HARNESS-SHARES-DB
+
+sleep 1;
+ok(1, "pass");
+sleep 1;
+
+done_testing;

--- a/t/unit/Test2/Harness/Runner/State.t
+++ b/t/unit/Test2/Harness/Runner/State.t
@@ -1,0 +1,237 @@
+use Test2::V0 -target => 'Test2::Harness::Runner::State';
+# HARNESS-DURATION-SHORT
+
+use ok $CLASS;
+
+use File::Temp qw/tempdir/;
+
+use Test2::Harness::Settings;
+
+my $RUN_ID = 'test-run';
+
+# Drive the scheduler by hand and check which tasks it is willing to run
+# together.
+#
+# 'tasks' is an ordered list of NAME => TASK_SPEC pairs; the spec carries only
+# what the case is about (usually 'conflicts' and/or 'shares'), everything else
+# gets a default.
+#
+# 'steps' is an ordered list of pairs describing what should happen:
+#
+#   running => \@names   Let the scheduler start everything it can, then check
+#                        that exactly these tasks are running.
+#   stop    => \@names   Pretend these tasks finished. Nothing forks here, so
+#                        this is the only way a task ever completes.
+#   queue   => \@tasks   Queue more NAME => TASK_SPEC pairs mid-run.
+sub schedule_ok {
+    my ($name, %params) = @_;
+
+    my @tasks     = @{$params{tasks}};
+    my @steps     = @{$params{steps}};
+    my $job_count = $params{job_count} // 10;
+
+    my $ctx = context();
+
+    my $settings = Test2::Harness::Settings->new(
+        runner => {
+            job_count     => $job_count,
+            slots_per_job => $job_count,
+            resources     => [],
+        },
+    );
+
+    my $state = $CLASS->new(
+        workdir      => tempdir(CLEANUP => 1),
+        settings     => $settings,
+        eager_stages => {},
+    );
+
+    $state->queue_run({run_id => $RUN_ID});
+    $state->stage_ready('DEFAULT');
+
+    my %name_for;
+    my $queue = sub {
+        my (@tasks) = @_;
+
+        while (@tasks) {
+            my ($task_name, $spec) = splice(@tasks, 0, 2);
+
+            my $job_id = "job-$task_name";
+            $name_for{$job_id} = $task_name;
+
+            $state->queue_task({
+                run_id      => $RUN_ID,
+                job_id      => $job_id,
+                category    => 'general',
+                duration    => 'short',
+                use_preload => 1,
+                %$spec,
+            });
+        }
+    };
+
+    $queue->(@tasks);
+
+    my $out = subtest $name => sub {
+        while (@steps) {
+            my ($action, $args) = splice(@steps, 0, 2);
+
+            if ($action eq 'running') {
+                1 while $state->advance;
+
+                my @running = map { $name_for{$_} } keys %{$state->running_tasks // {}};
+                is([sort @running], [sort @$args], "Running: " . join(', ' => sort @$args));
+            }
+            elsif ($action eq 'stop') {
+                $state->stop_task("job-$_") for @$args;
+            }
+            elsif ($action eq 'queue') {
+                $queue->(@$args);
+            }
+            else {
+                die "Unknown step '$action'";
+            }
+        }
+    };
+
+    $ctx->release;
+
+    return $out;
+}
+
+schedule_ok(
+    "Two exclusive claims on one name cannot run together",
+    tasks => [
+        a => {conflicts => ['db']},
+        b => {conflicts => ['db']},
+    ],
+    steps => [
+        running => [qw/a/],
+        stop    => [qw/a/],
+        running => [qw/b/],
+    ],
+);
+
+schedule_ok(
+    "Any number of shared claims on one name run together",
+    tasks => [
+        a => {shares => ['db']},
+        b => {shares => ['db']},
+        c => {shares => ['db']},
+    ],
+    steps => [running => [qw/a b c/]],
+);
+
+schedule_ok(
+    "Running shared claims keep an exclusive claim waiting, then release it",
+    tasks => [
+        a => {shares => ['db']},
+        b => {shares => ['db']},
+    ],
+    steps => [
+        running => [qw/a b/],
+        queue   => [c => {conflicts => ['db']}],
+        running => [qw/a b/],
+        stop    => [qw/a/],
+        running => [qw/b/],
+        stop    => [qw/b/],
+        running => [qw/c/],
+    ],
+);
+
+schedule_ok(
+    "An exclusive claim is picked ahead of shared claims on the same name",
+    tasks => [
+        a => {shares    => ['db']},
+        b => {shares    => ['db']},
+        c => {conflicts => ['db']},
+    ],
+    steps => [
+        running => [qw/c/],
+        stop    => [qw/c/],
+        running => [qw/a b/],
+    ],
+);
+
+schedule_ok(
+    "An exclusive claim keeps shared claims waiting",
+    tasks => [
+        a => {conflicts => ['db']},
+        b => {shares    => ['db']},
+        c => {shares    => ['db']},
+    ],
+    steps => [
+        running => [qw/a/],
+        stop    => [qw/a/],
+        running => [qw/b c/],
+    ],
+);
+
+schedule_ok(
+    "Claims on unrelated names do not interact",
+    tasks => [
+        a => {shares    => ['db']},
+        b => {conflicts => ['mysql']},
+        c => {shares    => ['mysql']},
+        d => {conflicts => ['db']},
+    ],
+    steps => [
+        running => [qw/b d/],
+        stop    => [qw/b d/],
+        running => [qw/a c/],
+    ],
+);
+
+schedule_ok(
+    "One task can hold an exclusive claim and a shared claim at once",
+    tasks => [
+        a => {conflicts => ['db'], shares => ['mysql']},
+        b => {shares    => ['mysql']},
+        c => {shares    => ['db']},
+        d => {conflicts => ['mysql']},
+    ],
+    steps => [
+        running => [qw/a b/],
+        stop    => [qw/a b/],
+        running => [qw/c d/],
+    ],
+);
+
+schedule_ok(
+    "A task with no 'shares' key at all still dispatches",
+    tasks => [
+        a => {},
+        b => {conflicts => ['db']},
+    ],
+    steps => [running => [qw/a b/]],
+);
+
+schedule_ok(
+    "A name claimed both ways by one task does not block that task",
+    tasks => [
+        a => {conflicts => ['db'], shares => ['db']},
+        b => {shares    => ['db']},
+    ],
+    steps => [
+        running => [qw/a/],
+        stop    => [qw/a/],
+        running => [qw/b/],
+    ],
+);
+
+schedule_ok(
+    "The job limiter still caps how many run at once",
+    job_count => 2,
+    tasks     => [
+        a => {shares => ['db']},
+        b => {shares => ['db']},
+        c => {shares => ['db']},
+    ],
+    steps => [
+        running => [qw/a b/],
+        stop    => [qw/a b/],
+        running => [qw/c/],
+    ],
+);
+
+done_testing;

--- a/t/unit/Test2/Harness/TestFile.t
+++ b/t/unit/Test2/Harness/TestFile.t
@@ -27,6 +27,14 @@ my $tmp = gen_temp(
     conflicts3 => "# HARNESS-CONFLICTS PASSWD\n# HARNESS-CONFLICTS DAEMON   # Nothing to see here\n",
     conflicts4 => "# HARNESS-CONFLICTS PASSWD DAEMON\n# HARNESS-CONFLICTS PASSWD\n# HARNESS-CONFLICTS PASSWD\n# HARNESS-CONFLICTS PASSWD DAEMON\n",
 
+    shares1 => "# HARNESS-SHARES PASSWD\n",
+    shares2 => "# HARNESS-SHARES-PASSWD\n",
+    shares3 => "# HARNESS-SHARES PASSWD DAEMON\n",
+    shares4 => "# HARNESS-SHARES PASSWD\n# HARNESS-SHARES-DAEMON   # Nothing to see here\n",
+    shares5 => "# HARNESS-SHARES PASSWD DAEMON\n# HARNESS-SHARES PASSWD\n# HARNESS-SHARES-PASSWD\n",
+
+    both => "# HARNESS-CONFLICTS DAEMON\n# HARNESS-SHARES PASSWD DAEMON\n",
+
     extra_comments => "#!/usr/bin/perl\n\nuse strict;\n# comment here\n use warnings\n\n# copyright Dewey Cheatem and Howe\n# HARNESS-CAT-LONG\n# HARNESS-NO-TIMEOUT\n# HARNESS-USE-ISOLATION\n",
 
     smoke1     => "#HARNESS-SMOKE\n",
@@ -123,6 +131,7 @@ subtest taint => sub {
             non_perl    => 0,
             smoke       => 0,
             conflicts   => [],
+            shares      => [],
             via         => ['xxx'],
             rank        => T(),
             run_id      => FDNE(),
@@ -159,6 +168,7 @@ subtest warn => sub {
             non_perl    => 0,
             smoke       => 0,
             conflicts   => [],
+            shares      => [],
             run_id      => FDNE(),
         },
         "Got queue item data",
@@ -199,6 +209,7 @@ subtest notime => sub {
             non_perl    => 0,
             smoke       => 0,
             conflicts   => [],
+            shares      => [],
             run_id      => FDNE(),
         },
         "Got queue item data",
@@ -248,6 +259,7 @@ subtest all => sub {
             use_timeout => 0,
             smoke       => 0,
             conflicts   => [],
+            shares      => [],
             binary      => 0,
             non_perl    => 0,
             run_id      => FDNE(),
@@ -303,6 +315,7 @@ subtest med2 => sub {
             non_perl    => 0,
             smoke       => 0,
             conflicts   => [],
+            shares      => [],
         },
         "Got queue item data",
     );
@@ -355,6 +368,7 @@ subtest med1 => sub {
             non_perl    => 0,
             smoke       => 0,
             conflicts   => [],
+            shares      => [],
         },
         "Got queue item data",
     );
@@ -409,6 +423,7 @@ subtest long => sub {
             non_perl    => 0,
             smoke       => 0,
             conflicts   => [],
+            shares      => [],
         },
         "Got queue item data",
     );
@@ -461,6 +476,7 @@ subtest extra_comments => sub {
             non_perl    => 0,
             smoke       => 0,
             conflicts   => [],
+            shares      => [],
         },
         "Got queue item data",
     );
@@ -479,6 +495,33 @@ subtest conflicts => sub {
     $parsed_file = $CLASS->new(file => File::Spec->catfile($tmp, 'conflicts4'));
     is([sort @{$parsed_file->conflicts_list}], ['daemon', 'passwd'], "Duplicate conflict lines only lead to 2 conflict items.");
 
+};
+
+sub shares_in {
+    my ($name) = @_;
+    my $file = $CLASS->new(file => File::Spec->catfile($tmp, $name));
+    return [sort @{$file->shares_list}];
+}
+
+subtest shares => sub {
+    is(shares_in('shares1'), ['passwd'],           "1 share on 1 line is reflected as an array");
+    is(shares_in('shares2'), ['passwd'],           "dashes and spaces delimit the same way");
+    is(shares_in('shares3'), ['daemon', 'passwd'], "1 share line with 2 share categories");
+    is(shares_in('shares4'), ['daemon', 'passwd'], "2 share lines with a comment on one of them");
+    is(shares_in('shares5'), ['daemon', 'passwd'], "Duplicate share lines only lead to 2 share items");
+};
+
+subtest shares_and_conflicts => sub {
+    my $file = $CLASS->new(file => File::Spec->catfile($tmp, 'both'));
+
+    is(
+        warnings { $file->headers },
+        ["'daemon' is listed as both a conflict and a share in " . $file->file . ", treating it as a conflict.\n"],
+        "Warned about the name claimed both exclusively and shared",
+    );
+
+    is([sort @{$file->conflicts_list}], ['daemon'], "Exclusive claim was kept");
+    is([sort @{$file->shares_list}],    ['passwd'], "Shared claim on the same name was dropped");
 };
 
 subtest binary => sub {
@@ -521,6 +564,7 @@ subtest binary => sub {
             io_events   => 1,
             use_timeout => 1,
             conflicts   => [],
+            shares      => [],
             binary      => 1,
             non_perl    => 1,
             smoke       => 0,
@@ -557,6 +601,7 @@ subtest not_perl => sub {
             io_events   => 1,
             use_timeout => 1,
             conflicts   => [],
+            shares      => [],
             binary      => 0,
             non_perl    => 1,
             smoke       => 0,
@@ -594,6 +639,7 @@ subtest not_env_perl => sub {
             io_events   => 1,
             use_timeout => 1,
             conflicts   => [],
+            shares      => [],
             smoke       => 0,
             binary      => 0,
             non_perl    => 1,
@@ -629,6 +675,7 @@ subtest smoke => sub {
             non_perl    => 0,
             smoke       => 1,
             conflicts   => [],
+            shares      => [],
         },
         "Got queue item data",
     );


### PR DESCRIPTION
Right now if you have ten tests, and one of them can't run at the same time as the others, you end up putting HARNESS-CONFLICTS-WHATEVER at the top of all ten, and now they're strictly serialized.

With this branch you get HARNESS-SHARES-WHATEVER.  The nine friendly tests get that, and can run alongside each other, but the greedy test keeps HARNESS-CONFLICTS-WHATEVER and now won't run with any of the others.

If you declare both in one file, it's exclusive and warns.

Bonus: tests for Test2::Harness::Runner::State